### PR TITLE
Exclude not to be tested lines from codecov

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,13 @@ omit =
     # Omit generated versioneer
     openff/bespokefit/_version.py
 
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:
+
 [flake8]
 # Flake8, PyFlakes, etc
 max-line-length = 88


### PR DESCRIPTION
## Description

This PR updates the codecov settings to not include lines which are not expected to be tested, including code within
a `__main__` statement, type checking imports, and `NotImplemented` exceptions.

This PR also adds a new pragma which can be used to explicitly state that blocks of code should be [excluded from the codecov counts](https://coverage.readthedocs.io/en/coverage-4.3.3/excluding.html#excluding-code-from-coverage-py). 

## Status
- [X] Ready to go