### PR TITLE
[GENREF] Refactor FB targets to handle QC records in batches

### DIFF
--- a/openff/bespokefit/optimizers/forcebalance/factories.py
+++ b/openff/bespokefit/optimizers/forcebalance/factories.py
@@ -110,6 +110,15 @@ class _TargetFactory(Generic[T], abc.ABC):
 
                 progress_bar.update(len(page_results))
 
+        missing_records = {*record_ids} - {*results}
+
+        if len(missing_records) > 0:
+
+            raise QCRecordMissMatchError(
+                f"The follow QC records could not be retrieved from the server at "
+                f"{qc_client.address}: {missing_records}"
+            )
+
         return [*results.values()]
 
     @classmethod
@@ -160,7 +169,7 @@ class _TargetFactory(Generic[T], abc.ABC):
     @classmethod
     def _batch_qc_records(
         cls, target: TargetSchema, qc_records: List[RecordBase]
-    ) -> Dict[str, RecordBase]:
+    ) -> Dict[str, List[RecordBase]]:
         """A function which places the input QC records into per target batches.
 
         For most targets there will be a single record per target, however certain

--- a/openff/bespokefit/tests/conftest.py
+++ b/openff/bespokefit/tests/conftest.py
@@ -96,7 +96,7 @@ def general_optimization_schema(
 
     # Mock the QC fractal client to retrieve our pre-calculated result records.
     def mock_query(*_, **kwargs):
-        return [records_by_id[kwargs["id"]]]
+        return [records_by_id[record_id] for record_id in kwargs["id"]]
 
     monkeypatch.setattr(FractalClient, "query_results", mock_query)
     monkeypatch.setattr(FractalClient, "query_procedures", mock_query)

--- a/openff/bespokefit/tests/conftest.py
+++ b/openff/bespokefit/tests/conftest.py
@@ -96,6 +96,10 @@ def general_optimization_schema(
 
     # Mock the QC fractal client to retrieve our pre-calculated result records.
     def mock_query(*_, **kwargs):
+
+        if kwargs["skip"] > 0:
+            return []
+
         return [records_by_id[record_id] for record_id in kwargs["id"]]
 
     monkeypatch.setattr(FractalClient, "query_results", mock_query)

--- a/openff/bespokefit/tests/optimizers/forcebalance/test_factories.py
+++ b/openff/bespokefit/tests/optimizers/forcebalance/test_factories.py
@@ -155,6 +155,21 @@ def test_generate_optimization_target(qc_optimization_record: ResultRecord):
         assert os.path.isfile("optget_options.txt")
 
 
+def test_opt_geo_batching(qc_optimization_record: ResultRecord):
+
+    qc_records = [qc_optimization_record] * 120
+
+    target_batches = OptGeoTargetFactory._batch_qc_records(
+        OptGeoTargetSchema(), qc_records
+    )
+
+    assert len(target_batches) == 3
+
+    assert len(target_batches["opt-geo-batch-0"]) == 50
+    assert len(target_batches["opt-geo-batch-1"]) == 50
+    assert len(target_batches["opt-geo-batch-2"]) == 20
+
+
 def test_generate_vibration_target(qc_hessian_record: ResultRecord):
     with temporary_cd():
 


### PR DESCRIPTION
## Description

This PR refactors the FB target factories to handle the retrieval of QC records in batches, and generalizes the code to potentially expect batches of QC records per target to generate.

## Status
- [X] Ready to go