### PR TITLE
Fix target reference data discrimination order

### DIFF
--- a/openff/bespokefit/schema/targets.py
+++ b/openff/bespokefit/schema/targets.py
@@ -20,7 +20,7 @@ class BaseTargetSchema(SchemaBase, abc.ABC):
         1.0, description="The amount to weight the target by."
     )
 
-    reference_data: Optional[Union[BespokeQCData, Any]]
+    reference_data: Optional[Union[Any, BespokeQCData]]
 
     extras: Dict[str, str] = Field(
         {},
@@ -58,7 +58,7 @@ class TorsionProfileTargetSchema(BaseTargetSchema):
     type: Literal["TorsionProfile"] = "TorsionProfile"
 
     reference_data: Optional[
-        Union[BespokeQCData, TorsionDriveResultCollection]
+        Union[TorsionDriveResultCollection, BespokeQCData]
     ] = Field(
         None,
         description="The reference QC data (either existing or to be generated on the "
@@ -85,7 +85,7 @@ class AbInitioTargetSchema(BaseTargetSchema):
     type: Literal["AbInitio"] = "AbInitio"
 
     reference_data: Optional[
-        Union[BespokeQCData, TorsionDriveResultCollection]
+        Union[TorsionDriveResultCollection, BespokeQCData]
     ] = Field(
         None,
         description="The reference QC data (either existing or to be generated on the "
@@ -114,7 +114,7 @@ class VibrationTargetSchema(BaseTargetSchema):
 
     type: Literal["Vibration"] = "Vibration"
 
-    reference_data: Optional[Union[BespokeQCData, BasicResultCollection]] = Field(
+    reference_data: Optional[Union[BasicResultCollection, BespokeQCData]] = Field(
         None,
         description="The reference QC data (either existing or to be generated on the "
         "fly) to fit against.",
@@ -135,7 +135,7 @@ class OptGeoTargetSchema(BaseTargetSchema):
     type: Literal["OptGeo"] = "OptGeo"
 
     reference_data: Optional[
-        Union[BespokeQCData, OptimizationResultCollection]
+        Union[OptimizationResultCollection, BespokeQCData]
     ] = Field(
         None,
         description="The reference QC data (either existing or to be generated on the "

--- a/openff/bespokefit/tests/conftest.py
+++ b/openff/bespokefit/tests/conftest.py
@@ -175,7 +175,7 @@ def qc_hessian_results(
     )
 
     monkeypatch.setattr(
-        OptimizationResultCollection,
+        BasicResultCollection,
         "to_records",
         lambda self: [qc_hessian_record],
     )


### PR DESCRIPTION
## Description

This PR fixes a bug introduced in #21 whereby target models will incorrectly assume that the reference data is bespoke rather than a result collection due to a quirk of how pydantic discriminates `Union` types.

## Status
- [ ] Ready to go