### PR TITLE
Drop CI pydantic pin

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -19,7 +19,7 @@ dependencies:
 
     ### Core dependencies.
 
-  - pydantic ==1.7.2
+  - pydantic
   - pyyaml
   - tqdm
   - openff-toolkit-base

--- a/devtools/conda-envs/xtb.yaml
+++ b/devtools/conda-envs/xtb.yaml
@@ -19,7 +19,7 @@ dependencies:
 
     ### Core dependencies.
 
-  - pydantic ==1.7.2
+  - pydantic
   - pyyaml
   - tqdm
   - openff-toolkit-base


### PR DESCRIPTION
## Description

This PR unpins `pydantic` in the CI environments as the pin is no longer needed.

## Status
- [X] Ready to go