### PR TITLE
Add fixed hydrogen InChI to fragment data

### DIFF
--- a/openff/bespokefit/fragmentation/fragmenter.py
+++ b/openff/bespokefit/fragmentation/fragmenter.py
@@ -106,6 +106,17 @@ class WBOFragmenter(FragmentEngine):
                 # get the fragment parent mapping
                 frag_dihedral = data["dihedral"][0][1:3]
 
+                # Add fixed-hydrogen InChIs which are now required but not exported
+                # by the old version of fragmenter.
+                data["identifiers"].update(
+                    {
+                        "fixed_hydrogen_inchi": off_frag.to_inchi(fixed_hydrogens=True),
+                        "fixed_hydrogen_inchi_key": off_frag.to_inchikey(
+                            fixed_hydrogens=True
+                        ),
+                    }
+                )
+
                 # in some cases we get one fragment back which is the parent molecule
                 # we should not work out a mapping
                 if not molecule.is_isomorphic_with(off_frag):


### PR DESCRIPTION
## Description

This PR adds fixed hydrogen InChI identifiers to fragment data which is required since https://github.com/openforcefield/openff-qcsubmit/pull/123.

## Status
- [X] Ready to go