### PR TITLE
Fix typo in opt geo target options file name

### DIFF
--- a/openff/bespokefit/optimizers/forcebalance/factories.py
+++ b/openff/bespokefit/optimizers/forcebalance/factories.py
@@ -477,7 +477,7 @@ class OptGeoTargetFactory(_TargetFactory[OptGeoTargetSchema]):
             off_molecule.to_file(f"{record_name}.sdf", "SDF")
 
         # Create the options file
-        with open("optget_options.txt", "w") as file:
+        with open("optgeo_options.txt", "w") as file:
             file.write(OptGeoOptionsTemplate.generate(target, record_names))
 
 

--- a/openff/bespokefit/tests/optimizers/forcebalance/test_factories.py
+++ b/openff/bespokefit/tests/optimizers/forcebalance/test_factories.py
@@ -156,7 +156,7 @@ def test_generate_optimization_target(
         for (index, extension) in itertools.product([0, 1], ["xyz", "sdf", "pdb"]):
             assert os.path.isfile(f"{qc_optimization_record[0].id}-{index}.{extension}")
 
-        assert os.path.isfile("optget_options.txt")
+        assert os.path.isfile("optgeo_options.txt")
 
 
 def test_opt_geo_batching(qc_optimization_record: ResultRecord):


### PR DESCRIPTION
## Description

This PR fixes a typo which caused opt geo target options to be named `optget_options.txt` rather than `optgeo_options.txt` as expected.

## Status
- [X] Ready to go