### PR TITLE
Fix opt geo batch size passed as extra

### DIFF
--- a/openff/bespokefit/optimizers/forcebalance/factories.py
+++ b/openff/bespokefit/optimizers/forcebalance/factories.py
@@ -427,7 +427,7 @@ class OptGeoTargetFactory(_TargetFactory[OptGeoTargetSchema]):
         cls, target: OptGeoTargetSchema, qc_records: List[RecordBase]
     ):
 
-        batch_size = target.extras.get("batch_size", 50)
+        batch_size = int(target.extras.get("batch_size", 50))
 
         n_records = len(qc_records)
         n_targets = (n_records + batch_size - 1) // batch_size

--- a/openff/bespokefit/tests/optimizers/forcebalance/test_factories.py
+++ b/openff/bespokefit/tests/optimizers/forcebalance/test_factories.py
@@ -164,14 +164,14 @@ def test_opt_geo_batching(qc_optimization_record: ResultRecord):
     qc_records = [qc_optimization_record] * 120
 
     target_batches = OptGeoTargetFactory._batch_qc_records(
-        OptGeoTargetSchema(), qc_records
+        OptGeoTargetSchema(extras={"batch_size": "51"}), qc_records
     )
 
     assert len(target_batches) == 3
 
-    assert len(target_batches["opt-geo-batch-0"]) == 50
-    assert len(target_batches["opt-geo-batch-1"]) == 50
-    assert len(target_batches["opt-geo-batch-2"]) == 20
+    assert len(target_batches["opt-geo-batch-0"]) == 51
+    assert len(target_batches["opt-geo-batch-1"]) == 51
+    assert len(target_batches["opt-geo-batch-2"]) == 18
 
 
 def test_generate_vibration_target(qc_hessian_record: Tuple[ResultRecord, Molecule]):


### PR DESCRIPTION
## Description

This PR fixes passing the batch size to FB OptGeo targets as an extra which gets converted to a string by the schema.

## Status
- [X] Ready to go