### PR TITLE
Fix pdb typo in FB vibration target template

### DIFF
--- a/openff/bespokefit/data/templates/force-balance/vibration-target.txt
+++ b/openff/bespokefit/data/templates/force-balance/vibration-target.txt
@@ -5,7 +5,7 @@ weight {{ weight }}
 type VIBRATION_SMIRNOFF
 
 mol2 input.sdf
-pdb conf.pdb
+coords conf.pdb
 
 writelevel 1
 


### PR DESCRIPTION
## Description

This PR fixes a typo in the ForceBalance vibration target template whereby `pdb` was used instead of the correct `coords`.

## Status
- [X] Ready to go