### PR TITLE
Add initial `openff-bespoke prepare` CLI

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -25,6 +25,7 @@ dependencies:
   - openff-toolkit-base
   - rdkit
   - openff-forcefields
+  - click
 
     # openff-qcsubmit needed until release
   - qcportal

--- a/devtools/conda-envs/xtb.yaml
+++ b/devtools/conda-envs/xtb.yaml
@@ -25,6 +25,7 @@ dependencies:
   - openff-toolkit-base
   - rdkit
   - openff-forcefields
+  - click
 
     # openff-qcsubmit needed until release
   - qcportal

--- a/openff/bespokefit/cli/__init__.py
+++ b/openff/bespokefit/cli/__init__.py
@@ -1,0 +1,3 @@
+from openff.bespokefit.cli.cli import cli
+
+__all__ = [cli]

--- a/openff/bespokefit/cli/cli.py
+++ b/openff/bespokefit/cli/cli.py
@@ -1,0 +1,11 @@
+import click
+
+from openff.bespokefit.cli.prepare import prepare_cli
+
+
+@click.group()
+def cli():
+    """The root group for all CLI commands."""
+
+
+cli.add_command(prepare_cli)

--- a/openff/bespokefit/cli/prepare.py
+++ b/openff/bespokefit/cli/prepare.py
@@ -1,0 +1,62 @@
+import json
+
+import click
+from click import ClickException
+from pydantic import ValidationError
+
+from openff.bespokefit.optimizers import get_optimizer
+from openff.bespokefit.schema.fitting import (
+    BespokeOptimizationSchema,
+    OptimizationSchema,
+)
+
+_SCHEMA_TYPES = {"general": OptimizationSchema, "bespoke": BespokeOptimizationSchema}
+
+
+@click.command("prepare")
+@click.option(
+    "-i",
+    "--input",
+    "input_path",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+    help="The file path to a JSON serialized optimization schema. This can be "
+    "either a general or a bespoke schema.",
+)
+def prepare_cli(input_path):
+    """Prepare an optimizations' input files based on its schema."""
+
+    _general_error_text = "the input path did not point to a valid optimization schema"
+
+    try:
+
+        with open(input_path) as file:
+            schema_contents = json.load(file)
+
+    except json.JSONDecodeError:
+
+        raise ClickException(
+            f"{_general_error_text}\n\nThe contents could not be parsed as JSON."
+        )
+
+    schema_type_string = schema_contents.get("type", None)
+
+    if schema_type_string is None:
+        raise ClickException(
+            f"{_general_error_text}\n\nThe optimization type was not specified by "
+            f"the schema."
+        )
+    if schema_type_string not in _SCHEMA_TYPES:
+        raise ClickException(
+            f"{_general_error_text}\n\nThe optimization type ({schema_type_string}) "
+            f"is not supported."
+        )
+
+    schema_type = _SCHEMA_TYPES[schema_type_string]
+
+    try:
+        schema: OptimizationSchema = schema_type.parse_file(input_path)
+    except ValidationError as e:
+        raise ClickException(f"{_general_error_text}\n\n({e})")
+
+    optimizer = get_optimizer(schema.optimizer.type)
+    optimizer.prepare(schema, "optimization-inputs" if schema.id is None else schema.id)

--- a/openff/bespokefit/tests/cli/conftest.py
+++ b/openff/bespokefit/tests/cli/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture(scope="module")
+def runner() -> CliRunner:
+    """Creates a new click CLI runner object."""
+    click_runner = CliRunner()
+
+    with click_runner.isolated_filesystem():
+        yield click_runner

--- a/openff/bespokefit/tests/cli/test_prepare.py
+++ b/openff/bespokefit/tests/cli/test_prepare.py
@@ -1,0 +1,42 @@
+import pytest
+
+from openff.bespokefit.cli.prepare import prepare_cli
+from openff.bespokefit.optimizers import ForceBalanceOptimizer
+
+
+@pytest.mark.parametrize(
+    "schema_contents, expected_match",
+    [
+        ("abc", "The contents could not be parsed as JSON."),
+        ("{}", "The optimization type was not specified"),
+        ('{"type": "abc"}', "The optimization type (abc) is not supported"),
+        ('{"type": "general"}', "4 validation errors for"),
+    ],
+)
+def test_prepare_errors(runner, schema_contents, expected_match):
+
+    with open("input.json", "w") as file:
+        file.write(schema_contents)
+
+    arguments = ["-i", "input.json"]
+
+    result = runner.invoke(prepare_cli, arguments)
+    assert result.exit_code != 0
+
+    assert expected_match in result.output
+    assert "the input path did not point to a valid optimization" in result.output
+
+
+def test_prepare(runner, bespoke_optimization_schema, monkeypatch):
+
+    monkeypatch.setattr(ForceBalanceOptimizer, "prepare", lambda *args, **kwargs: None)
+
+    with open("input.json", "w") as file:
+        file.write(bespoke_optimization_schema.json())
+
+    arguments = ["-i", "input.json"]
+
+    result = runner.invoke(prepare_cli, arguments)
+
+    if result.exit_code != 0:
+        raise result.exception

--- a/setup.py
+++ b/setup.py
@@ -42,15 +42,11 @@ setup(
     include_package_data=True,
     # Allows `setup.py test` to work correctly with pytest
     setup_requires=[] + pytest_runner,
-    install_requires=[]
-    # Additional entries you may want simply uncomment the lines you want and fill in the data
-    # url='http://www.my_package.com',  # Website
-    # install_requires=[],              # Required packages, pulls from pip if needed; do not use for Conda deployment
-    # platforms=['Linux',
-    #            'Mac OS-X',
-    #            'Unix',
-    #            'Windows'],            # Valid platforms your code works on, adjust to your flavor
-    # python_requires=">=3.5",          # Python version restrictions
-    # Manual control if final package is compressible or not, set False to prevent the .egg from being made
-    # zip_safe=False,
+    install_requires=[],
+    # Set up the main CLI entry points
+    entry_points={
+        'console_scripts': [
+            'openff-bespoke=openff.bespokefit.cli:cli',
+        ],
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     # Set up the main CLI entry points
     entry_points={
         'console_scripts': [
-            'openff-bespoke=openff.bespokefit.cli:cli',
+            'openff-bespokefit=openff.bespokefit.cli:cli',
         ],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     # Set up the main CLI entry points
     entry_points={
         'console_scripts': [
-            'openff-bespokefit=openff.bespokefit.cli:cli',
+            'openff-bespoke=openff.bespokefit.cli:cli',
         ],
     }
 )


### PR DESCRIPTION
## Description

This PR exposes a new `openff-bespoke prepare` CLI:

```
Usage: openff-bespoke prepare [OPTIONS]

  Prepare an optimizations' input files based on its schema.

Options:
  -i, --input FILE  The file path to a JSON serialized optimization schema.
                    This can be either a general or a bespoke schema.

  --help            Show this message and exit.
```

which is built around the `click` package. Currently if a `bespoke` schema is used as input no QC is spun up and generated when missing, although in future we may consider adding this.

## Status
- [X] Ready to go