### PR TITLE
Retrieve `ambertools` version from conda as backup

### DIFF
--- a/openff/bespokefit/utilities/provenance.py
+++ b/openff/bespokefit/utilities/provenance.py
@@ -1,6 +1,25 @@
+import functools
+import re
+import subprocess
 from typing import Dict, Optional
 
 import pkg_resources
+
+
+@functools.lru_cache()
+def _get_conda_list_package_versions() -> Dict[str, str]:
+    """Returns the versions of any packages found while executing `conda list`."""
+
+    list_output = subprocess.check_output(["conda", "list"]).decode().split("\n")
+
+    package_versions = {}
+
+    for output_line in list_output[3:-1]:
+
+        package_name, package_version, *_ = re.split(" +", output_line)
+        package_versions[package_name] = package_version
+
+    return package_versions
 
 
 def get_ambertools_version() -> Optional[str]:
@@ -9,8 +28,9 @@ def get_ambertools_version() -> Optional[str]:
     try:
         distribution = pkg_resources.get_distribution("AmberTools")
         return distribution.version
+
     except pkg_resources.DistributionNotFound:
-        return None
+        return _get_conda_list_package_versions().get("ambertools", None)
 
 
 def get_openeye_versions() -> Dict[str, str]:


### PR DESCRIPTION
## Description

This fixes parsing the version of `ambertools` when using `21.0` or later.

## Status
- [X] Ready to go