### PR TITLE
Openff-Fragmenter update

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -40,10 +40,10 @@ dependencies:
     ### Bespoke dependencies
   - qcengine >=0.18.0
   - qcfractal >=0.15.4
-  - openeye-toolkits ==2019.10.2
   - chemper
-  - fragmenter ==0.0.7
+  - openeye-toolkits
   - basis_set_exchange
 
   - pip:
       - git+git://github.com/openforcefield/openff-qcsubmit.git@master
+      - git+git://github.com/openforcefield/openff-fragmenter.git@master

--- a/devtools/conda-envs/xtb.yaml
+++ b/devtools/conda-envs/xtb.yaml
@@ -40,11 +40,11 @@ dependencies:
     ### Bespoke dependencies
   - qcengine >=0.18.0
   - qcfractal >=0.15.4
-  - openeye-toolkits ==2019.10.2
+  - openeye-toolkits
   - chemper
-  - fragmenter ==0.0.7
   - basis_set_exchange
   - xtb-python
 
   - pip:
       - git+git://github.com/openforcefield/openff-qcsubmit.git@master
+      - git+git://github.com/openforcefield/openff-fragmenter.git@master

--- a/openff/bespokefit/fragmentation/__init__.py
+++ b/openff/bespokefit/fragmentation/__init__.py
@@ -15,5 +15,6 @@ __all__ = [
     register_fragment_engine,
     WBOFragmenter,
     PfizerFragmenter,
+    FragmentEngines,
     FragmentEngine,
 ]

--- a/openff/bespokefit/fragmentation/__init__.py
+++ b/openff/bespokefit/fragmentation/__init__.py
@@ -1,10 +1,11 @@
 from openff.bespokefit.fragmentation.base import (
+    FragmentEngines,
     deregister_fragment_engine,
     get_fragmentation_engine,
     list_fragment_engines,
     register_fragment_engine,
 )
-from openff.bespokefit.fragmentation.fragmenter import WBOFragmenter
+from openff.bespokefit.fragmentation.fragmenter import PfizerFragmenter, WBOFragmenter
 from openff.bespokefit.fragmentation.model import FragmentEngine
 
 __all__ = [
@@ -13,5 +14,6 @@ __all__ = [
     list_fragment_engines,
     register_fragment_engine,
     WBOFragmenter,
+    PfizerFragmenter,
     FragmentEngine,
 ]

--- a/openff/bespokefit/fragmentation/base.py
+++ b/openff/bespokefit/fragmentation/base.py
@@ -4,14 +4,15 @@ Register new fragmentation methods with bespokefit
 from typing import Dict, List, Union
 
 from openff.bespokefit.exceptions import FragmenterError
-from openff.bespokefit.fragmentation.fragmenter import WBOFragmenter
+from openff.bespokefit.fragmentation.fragmenter import PfizerFragmenter, WBOFragmenter
 from openff.bespokefit.fragmentation.model import FragmentEngine
 
-_fragment_engines: Dict[str, FragmentEngine] = {}
+FragmentEngines = Union[WBOFragmenter, PfizerFragmenter]
+_fragment_engines: Dict[str, FragmentEngines] = {}
 
 
 def register_fragment_engine(
-    fragment_engine: FragmentEngine, replace: bool = False
+    fragment_engine: FragmentEngines, replace: bool = False
 ) -> None:
     """
     Register a new valid fragment engine with bespokefit.
@@ -28,7 +29,7 @@ def register_fragment_engine(
     """
 
     if issubclass(type(fragment_engine), FragmentEngine):
-        fragment_name = fragment_engine.fragmentation_engine.lower()
+        fragment_name = fragment_engine.type.lower()
         if fragment_name not in _fragment_engines or (
             fragment_name in _fragment_engines and replace
         ):
@@ -36,7 +37,7 @@ def register_fragment_engine(
         else:
             raise FragmenterError(
                 f"An fragmentation engine is already registered under the name "
-                f"{fragment_engine.fragmentation_engine}, to replace this please use "
+                f"{fragment_engine.type}, to replace this please use "
                 f"the `replace=True` flag."
             )
     else:
@@ -46,7 +47,7 @@ def register_fragment_engine(
         )
 
 
-def deregister_fragment_engine(fragment_engine: Union[FragmentEngine, str]) -> None:
+def deregister_fragment_engine(fragment_engine: Union[FragmentEngines, str]) -> None:
     """
     Remove a frgamnetation engine from the list of valid fragmenters.
 
@@ -56,7 +57,7 @@ def deregister_fragment_engine(fragment_engine: Union[FragmentEngine, str]) -> N
     """
 
     try:
-        fragment_name = fragment_engine.fragmentation_engine.lower()
+        fragment_name = fragment_engine.type.lower()
     except AttributeError:
         fragment_name = fragment_engine.lower()
 
@@ -68,7 +69,7 @@ def deregister_fragment_engine(fragment_engine: Union[FragmentEngine, str]) -> N
         )
 
 
-def get_fragmentation_engine(fragmentation_engine: str, **kwargs) -> FragmentEngine:
+def get_fragmentation_engine(fragmentation_engine: str, **kwargs) -> FragmentEngines:
     """
     Get the fragmentation engine class from the list of registered optimizers in
     bespokefit by name.
@@ -108,3 +109,4 @@ def list_fragment_engines() -> List[str]:
 
 # register the built in optimizers
 register_fragment_engine(WBOFragmenter())
+register_fragment_engine(PfizerFragmenter())

--- a/openff/bespokefit/tests/conftest.py
+++ b/openff/bespokefit/tests/conftest.py
@@ -213,7 +213,7 @@ def general_optimization_schema(
 
 @pytest.fixture()
 def bespoke_optimization_schema() -> BespokeOptimizationSchema:
-    """Create a workflow schema which targets the rotatable bond in ethane."""
+    """Create a workflow schema which targets the rotatable bond in biphenyl."""
 
     molecule = Molecule.from_smiles("c1ccc(cc1)c2cccc(c2)")
 

--- a/openff/bespokefit/tests/conftest.py
+++ b/openff/bespokefit/tests/conftest.py
@@ -35,6 +35,30 @@ from openff.bespokefit.schema.targets import (
 from openff.bespokefit.workflows.bespoke import BespokeWorkflowFactory
 
 
+@pytest.fixture(scope="function", autouse=True)
+def clear_force_balance_caches():
+    """A fixture which will clean the incredibly bug prone ``smirnoff_hack`` caches prior
+    to each test running."""
+
+    from forcebalance.smirnoff_hack import (
+        AT_TOOLKIT_CACHE_assign_partial_charges,
+        OE_TOOLKIT_CACHE_assign_partial_charges,
+        OE_TOOLKIT_CACHE_find_smarts_matches,
+        OE_TOOLKIT_CACHE_molecule_conformers,
+        RDK_TOOLKIT_CACHE_find_smarts_matches,
+        RDK_TOOLKIT_CACHE_molecule_conformers,
+        TOOLKIT_CACHE_ChemicalEnvironment_validate,
+    )
+
+    OE_TOOLKIT_CACHE_find_smarts_matches.clear()
+    RDK_TOOLKIT_CACHE_find_smarts_matches.clear()
+    TOOLKIT_CACHE_ChemicalEnvironment_validate.clear()
+    OE_TOOLKIT_CACHE_assign_partial_charges.clear()
+    AT_TOOLKIT_CACHE_assign_partial_charges.clear()
+    OE_TOOLKIT_CACHE_molecule_conformers.clear()
+    RDK_TOOLKIT_CACHE_molecule_conformers.clear()
+
+
 @pytest.fixture(scope="module")
 def qc_torsion_drive_record() -> Tuple[TorsionDriveRecord, Molecule]:
 
@@ -188,7 +212,6 @@ def general_optimization_schema(
     qc_torsion_drive_results: TorsionDriveResultCollection,
     qc_optimization_results: OptimizationResultCollection,
     qc_hessian_results: BasicResultCollection,
-    monkeypatch,
 ):
 
     optimization_schema = OptimizationSchema(

--- a/openff/bespokefit/tests/fragmentation/test_fragment_general.py
+++ b/openff/bespokefit/tests/fragmentation/test_fragment_general.py
@@ -1,21 +1,17 @@
 """
 Test the base and general methods of fragmentation.
 """
-import os
 
 import pytest
-from openff.toolkit.topology import Molecule
 
 from openff.bespokefit.exceptions import FragmenterError
 from openff.bespokefit.fragmentation import (
-    FragmentEngine,
     WBOFragmenter,
     deregister_fragment_engine,
     get_fragmentation_engine,
     list_fragment_engines,
     register_fragment_engine,
 )
-from openff.bespokefit.utilities import get_data_file_path
 
 
 def test_list_fragmentation_engines():

--- a/openff/bespokefit/tests/fragmentation/test_fragment_general.py
+++ b/openff/bespokefit/tests/fragmentation/test_fragment_general.py
@@ -23,7 +23,7 @@ def test_list_fragmentation_engines():
     Make sure all default fragmentation engines are listed.
     """
     engines = list_fragment_engines()
-    assert WBOFragmenter().fragmentation_engine.lower() in engines
+    assert WBOFragmenter().type.lower() in engines
 
 
 @pytest.mark.parametrize(
@@ -45,7 +45,7 @@ def test_get_fragmentation_engine_settings(settings):
     """
     name, extras = settings
     engine = get_fragmentation_engine(fragmentation_engine=name, **extras)
-    assert engine.fragmentation_engine == name
+    assert engine.type == name
     for att, value in extras.items():
         assert getattr(engine, att) == value
 
@@ -84,10 +84,10 @@ def test_removing_engines():
     Make sure once an engine is removed it does not show as listed.
     """
     engine = WBOFragmenter()
-    assert engine.fragmentation_engine.lower() in list_fragment_engines()
+    assert engine.type.lower() in list_fragment_engines()
     # now remove
     deregister_fragment_engine(fragment_engine=engine)
-    assert engine.fragmentation_engine.lower() not in list_fragment_engines()
+    assert engine.type.lower() not in list_fragment_engines()
 
     # now add back to not spoil tests
     register_fragment_engine(fragment_engine=engine)
@@ -113,155 +113,3 @@ def test_reregister_engine():
 
     # now try with replace true
     register_fragment_engine(fragment_engine=engine, replace=True)
-
-
-@pytest.mark.parametrize(
-    "molecules",
-    [
-        pytest.param(
-            (
-                "bace_parent.sdf",
-                "bace_parent.sdf",
-                {
-                    0: 0,
-                    1: 1,
-                    2: 2,
-                    3: 3,
-                    4: 4,
-                    5: 5,
-                    6: 6,
-                    7: 7,
-                    8: 8,
-                    9: 9,
-                    10: 10,
-                    11: 11,
-                    12: 12,
-                    13: 13,
-                    14: 14,
-                    15: 15,
-                    16: 16,
-                    17: 17,
-                    18: 18,
-                    19: 19,
-                    20: 20,
-                    21: 21,
-                    22: 22,
-                    23: 23,
-                    24: 24,
-                    25: 25,
-                    26: 26,
-                    27: 27,
-                    28: 28,
-                    29: 48,
-                    30: 30,
-                    31: 31,
-                    32: 32,
-                    33: 33,
-                    34: 34,
-                    35: 35,
-                    36: 36,
-                    37: 37,
-                    38: 38,
-                    39: 39,
-                    40: 40,
-                    41: 41,
-                    42: 42,
-                    43: 43,
-                    44: 44,
-                    45: 45,
-                    46: 46,
-                    47: 47,
-                    48: 29,
-                },
-            ),
-            id="Same molecule",
-        ),
-        pytest.param(
-            (
-                "bace_parent.sdf",
-                "bace_frag1.sdf",
-                {
-                    0: 7,
-                    2: 8,
-                    6: 9,
-                    10: 10,
-                    7: 18,
-                    3: 6,
-                    19: 38,
-                    11: 11,
-                    8: 17,
-                    4: 15,
-                    1: 14,
-                    5: 13,
-                    9: 12,
-                    21: 34,
-                    17: 35,
-                    13: 36,
-                    20: 37,
-                    18: 33,
-                    14: 32,
-                    12: 31,
-                },
-            ),
-            id="BACE parent fragment1 mapping",
-        ),
-        pytest.param(
-            (
-                "bace_parent.sdf",
-                "bace_frag2.sdf",
-                {
-                    0: 9,
-                    1: 8,
-                    3: 7,
-                    5: 6,
-                    4: 18,
-                    2: 10,
-                    22: 38,
-                    13: 5,
-                    7: 24,
-                    15: 1,
-                    6: 2,
-                    16: 4,
-                    36: 30,
-                    14: 0,
-                    33: 26,
-                    34: 27,
-                    35: 28,
-                    17: 25,
-                    12: 19,
-                    10: 20,
-                    8: 21,
-                    9: 22,
-                    11: 23,
-                    30: 46,
-                    31: 47,
-                    26: 44,
-                    27: 45,
-                    24: 42,
-                    25: 43,
-                    28: 40,
-                    29: 41,
-                    32: 39,
-                    21: 31,
-                    19: 32,
-                    18: 33,
-                },
-            ),
-            id="BACE parent fragment2 mapping",
-        ),
-    ],
-)
-def test_parent_fragment_mapping(molecules):
-    """
-    Test generating a parent fragment mapping.
-    """
-
-    molecule1, molecule2, atom_map = molecules
-    mol1 = Molecule.from_file(
-        get_data_file_path(os.path.join("test", "molecules", "bace", molecule1)), "sdf"
-    )
-    mol2 = Molecule.from_file(
-        get_data_file_path(os.path.join("test", "molecules", "bace", molecule2)), "sdf"
-    )
-    mapping = FragmentEngine._get_fragment_parent_mapping(fragment=mol2, parent=mol1)
-    assert mapping == atom_map

--- a/openff/bespokefit/tests/fragmentation/test_fragmentation.py
+++ b/openff/bespokefit/tests/fragmentation/test_fragmentation.py
@@ -1,12 +1,10 @@
 """
 Test specific fragmentation engines.
 """
-import os
 
 from openff.toolkit.topology import Molecule
 
-from openff.bespokefit.fragmentation import WBOFragmenter
-from openff.bespokefit.utilities import get_data_file_path
+from openff.bespokefit.fragmentation import PfizerFragmenter, WBOFragmenter
 
 
 def test_is_available():
@@ -21,38 +19,179 @@ def test_provenance():
     """
     Make sure the openeye and fragmenter versions are captured.
     """
-    engine = WBOFragmenter()
-    provenance = engine.provenance()
-    assert "fragmenter" in provenance
-    assert "openeye" in provenance
+    provenance = WBOFragmenter.provenance()
+    assert "openff-fragmenter" in provenance
+    assert "openeye.oequacpac" in provenance
+    assert "openff-toolkit" in provenance
 
 
-def test_normal_fragmentation():
+def test_wbo_fragmentation():
     """
     Test that a molecule can be fragmented successfully and produce the expected results.
     """
     # bace can be fragmented into 3 parts 2 of which are the same
     engine = WBOFragmenter()
-    engine.keep_non_rotor_ring_substituents = False
-    bace = Molecule.from_file(
-        file_path=get_data_file_path(
-            os.path.join("test", "molecules", "bace", "bace_parent.sdf")
-        ),
-        file_format="sdf",
+    engine.keep_non_rotor_ring_substituents = True
+    bace = Molecule.from_mapped_smiles(
+        "[H:30][c:6]1[c:7]([c:8]([c:16]([c:4]([c:5]1[H:29])[C@@:3]2([C:22](=[O:23])[N:20]([C:18](=[N+:17]2[H:37])[N:19]([H:38])[H:42])[C:21]([H:39])([H:40])[H:41])[C:2]([H:27])([H:28])[C:1]([H:24])([H:25])[H:26])[H:36])[c:9]3[c:10]([c:11]([c:12]([c:13]([c:15]3[H:35])[Cl:14])[H:34])[H:33])[H:32])[H:31]"
     )
     fragment_data = engine.fragment(molecule=bace)
     assert len(fragment_data) == 3
-
     fragments = [fragment.fragment_molecule for fragment in fragment_data]
     # make sure the fragments are correct
-    for fragment in ["bace_frag1.sdf", "bace_frag2.sdf"]:
-        frag_mol = Molecule.from_file(
-            file_path=get_data_file_path(
-                os.path.join("test", "molecules", "bace", fragment)
-            ),
-            file_format="sdf",
-        )
+    fragments_smiles = [
+        "[H:14][c:1]1[c:2]([c:5]([c:10]([c:6]([c:3]1[H:16])[H:19])[c:11]2[c:7]([c:4]([c:8]([c:12]([c:9]2[H:22])[Cl:13])[H:21])[H:17])[H:20])[H:18])[H:15]",
+        "[H:17][c:1]1[c:2]([c:4]([c:6]([c:5]([c:3]1[H:19])[H:21])[C@@:9]2([C:7](=[O:16])[N:13]([C:8](=[N+:14]2[H:30])[N:15]([H:31])[H:32])[C:11]([H:25])([H:26])[H:27])[C:12]([H:28])([H:29])[C:10]([H:22])([H:23])[H:24])[H:20])[H:18]",
+    ]
+    for smiles in fragments_smiles:
+        frag_mol = Molecule.from_mapped_smiles(smiles)
         assert frag_mol in fragments
+
+    # check the mapping
+    assert fragment_data[0].fragment_parent_mapping == {
+        0: 7,
+        1: 6,
+        2: 1,
+        3: 2,
+        4: 3,
+        5: 4,
+        6: 5,
+        8: 29,
+        9: 30,
+        10: 31,
+        11: 32,
+        12: 33,
+        13: 34,
+        14: 35,
+        15: 36,
+        16: 37,
+        17: 38,
+        18: 39,
+        19: 40,
+        20: 41,
+        21: 0,
+    }
+    assert fragment_data[1].fragment_parent_mapping == {
+        0: 41,
+        1: 2,
+        2: 1,
+        3: 6,
+        4: 5,
+        5: 4,
+        6: 3,
+        8: 29,
+        9: 8,
+        10: 9,
+        11: 10,
+        12: 11,
+        13: 12,
+        14: 13,
+        15: 14,
+        16: 15,
+        17: 16,
+        18: 17,
+        19: 18,
+        20: 19,
+        21: 20,
+        22: 21,
+        23: 22,
+        24: 23,
+        25: 24,
+        26: 25,
+        27: 26,
+        28: 27,
+        29: 28,
+        30: 7,
+        31: 0,
+    }
+    assert (
+        fragment_data[1].fragment_parent_mapping
+        == fragment_data[2].fragment_parent_mapping
+    )
+
+    # make sure all of the central bonds are different
+    torsions = set([fragment.parent_torsion for fragment in fragment_data])
+    assert len(torsions) == 3
+
+
+def test_pfizer_fragmentation():
+    """Make sure the Pfizer fragmenation method produces the expected results and parent mapping.
+    Produces slightly different fragments to the WBO method hence the test is split.
+    """
+    # bace can be fragmented into 3 parts 2 of which are the same
+    engine = PfizerFragmenter()
+    bace = Molecule.from_mapped_smiles(
+        "[H:30][c:6]1[c:7]([c:8]([c:16]([c:4]([c:5]1[H:29])[C@@:3]2([C:22](=[O:23])[N:20]([C:18](=[N+:17]2[H:37])[N:19]([H:38])[H:42])[C:21]([H:39])([H:40])[H:41])[C:2]([H:27])([H:28])[C:1]([H:24])([H:25])[H:26])[H:36])[c:9]3[c:10]([c:11]([c:12]([c:13]([c:15]3[H:35])[Cl:14])[H:34])[H:33])[H:32])[H:31]"
+    )
+    fragment_data = engine.fragment(molecule=bace)
+    assert len(fragment_data) == 3
+    fragments = [fragment.fragment_molecule for fragment in fragment_data]
+
+    fragments_smiles = [
+        "[H:1][c:2]1[c:7]([c:6]([c:5]([c:4]([c:3]1[H:22])[H:21])[c:10]2[c:15]([c:14]([c:13]([c:12]([c:11]2[H:20])[H:19])[H:18])[H:17])[H:16])[H:9])[H:8]",
+        "[H:1][c:2]1[c:7]([c:6]([c:5]([c:4]([c:3]1[H:30])[H:29])[C@@:10]2([C:11](=[O:12])[N:13]([C:14](=[N+:15]2[H:16])[H:17])[C:18]([H:19])([H:20])[H:21])[C:22]([H:23])([H:24])[C:25]([H:26])([H:27])[H:28])[H:9])[H:8]",
+    ]
+    for smiles in fragments_smiles:
+        frag_mol = Molecule.from_mapped_smiles(smiles)
+        assert frag_mol in fragments
+
+    # check the mapping
+    assert fragment_data[0].fragment_parent_mapping == {
+        0: 7,
+        1: 6,
+        2: 1,
+        3: 2,
+        4: 3,
+        5: 4,
+        6: 5,
+        8: 29,
+        9: 30,
+        10: 31,
+        11: 32,
+        12: 33,
+        13: 34,
+        14: 35,
+        15: 36,
+        17: 38,
+        18: 39,
+        19: 40,
+        20: 41,
+        21: 0,
+    }
+    assert fragment_data[1].fragment_parent_mapping == {
+        0: 41,
+        1: 2,
+        2: 1,
+        3: 6,
+        4: 5,
+        5: 4,
+        6: 3,
+        8: 29,
+        9: 8,
+        10: 9,
+        11: 10,
+        12: 11,
+        13: 12,
+        14: 13,
+        15: 14,
+        17: 18,
+        18: 19,
+        19: 20,
+        20: 21,
+        21: 22,
+        22: 23,
+        23: 24,
+        24: 25,
+        25: 26,
+        26: 27,
+        27: 28,
+        28: 7,
+        29: 0,
+    }
+    assert (
+        fragment_data[1].fragment_parent_mapping
+        == fragment_data[2].fragment_parent_mapping
+    )
 
     # make sure all of the central bonds are different
     torsions = set([fragment.parent_torsion for fragment in fragment_data])

--- a/openff/bespokefit/tests/schema/bespoke/test_tasks.py
+++ b/openff/bespokefit/tests/schema/bespoke/test_tasks.py
@@ -17,7 +17,7 @@ from openff.bespokefit.schema.bespoke.tasks import (
 from openff.bespokefit.schema.fitting import BespokeOptimizationSchema
 from openff.bespokefit.schema.optimizers import ForceBalanceSchema
 from openff.bespokefit.schema.targets import AbInitioTargetSchema
-from openff.bespokefit.utilities import get_data_file_path, get_molecule_cmiles
+from openff.bespokefit.utilities import get_data_file_path
 from openff.bespokefit.workflows.bespoke import BespokeWorkflowFactory
 
 
@@ -49,7 +49,7 @@ def ethane_opt_task(ethane) -> OptimizationTask:
     Return the ethane fitting entry.
     """
 
-    attributes = get_molecule_cmiles(molecule=ethane)
+    attributes = MoleculeAttributes.from_openff_molecule(molecule=ethane)
 
     entry = OptimizationTask(
         name="test",
@@ -88,7 +88,7 @@ def test_making_a_fitting_task(ethane, fitting_task):
     Try and a make a fitting task of each type for ethane.
     """
 
-    attributes = get_molecule_cmiles(molecule=ethane)
+    attributes = MoleculeAttributes.from_openff_molecule(molecule=ethane)
 
     task = fitting_task(
         input_conformers=[ethane.conformers[0].value_in_unit(unit.angstrom)],

--- a/openff/bespokefit/tests/utilities/test_utilities.py
+++ b/openff/bespokefit/tests/utilities/test_utilities.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-from openff.toolkit.topology import Molecule
 
 from openff.bespokefit.utilities import get_data_file_path, temporary_cd
 

--- a/openff/bespokefit/tests/utilities/test_utilities.py
+++ b/openff/bespokefit/tests/utilities/test_utilities.py
@@ -3,11 +3,7 @@ import os
 import pytest
 from openff.toolkit.topology import Molecule
 
-from openff.bespokefit.utilities import (
-    get_data_file_path,
-    get_molecule_cmiles,
-    temporary_cd,
-)
+from openff.bespokefit.utilities import get_data_file_path, temporary_cd
 
 
 def compare_paths(path_1: str, path_2: str) -> bool:
@@ -67,9 +63,3 @@ def test_temporary_cd():
         assert compare_paths(os.getcwd(), original_directory)
 
     assert compare_paths(os.getcwd(), original_directory)
-
-
-def test_get_molecule_cmiles():
-
-    cmiles = get_molecule_cmiles(Molecule.from_smiles("C"))
-    assert cmiles.canonical_smiles == "C"

--- a/openff/bespokefit/tests/workflows/test_bespoke.py
+++ b/openff/bespokefit/tests/workflows/test_bespoke.py
@@ -4,6 +4,7 @@ Test for the bespoke-fit workflow generator.
 import os
 
 import pytest
+from openff.qcsubmit.common_structures import MoleculeAttributes
 from openff.toolkit.topology import Molecule
 
 from openff.bespokefit.exceptions import (
@@ -21,18 +22,8 @@ from openff.bespokefit.schema.targets import (
     VibrationTargetSchema,
 )
 from openff.bespokefit.tests import does_not_raise
-from openff.bespokefit.utilities import (
-    get_data_file_path,
-    get_molecule_cmiles,
-    temporary_cd,
-)
+from openff.bespokefit.utilities import get_data_file_path, temporary_cd
 from openff.bespokefit.workflows.bespoke import BespokeWorkflowFactory
-
-bace_entries = [
-    "[h]c1c([c:1]([c:2](c(c1[h])[h])[c:3]2[c:4](c(c(c(c2[h])cl)[h])[h])[h])[h])[h]",
-    "[h]c1c([c:1]([c:2](c(c1[h])[h])[c@:3]2(c(=o)n(c(=[n+:4]2[h])n([h])[h])c([h])([h])[h])c3(c(c3([h])[h])([h])[h])[h])[h])[h]",
-    "[h]c1c(c(c(c(c1[h])[h])[c@:3]2(c(=o)n(c(=[n+:4]2[h])n([h])[h])c([h])([h])[h])[c:2]3([c:1](c3([h])[h])([h])[h])[h])[h])[h]",
-]
 
 
 @pytest.fixture()
@@ -167,7 +158,7 @@ def test_generate_fitting_task(target_schema, bace):
         target_schema=target_schema,
         molecule=molecule,
         fragment=False,
-        attributes=get_molecule_cmiles(molecule),
+        attributes=MoleculeAttributes.from_openff_molecule(molecule),
         dihedrals=[(8, 2, 1, 0)],
     )
 

--- a/openff/bespokefit/tests/workflows/test_bespoke.py
+++ b/openff/bespokefit/tests/workflows/test_bespoke.py
@@ -251,7 +251,7 @@ def test_optimization_schemas_from_results(qc_torsion_drive_results):
     factory = BespokeWorkflowFactory(optimizer=ForceBalanceSchema())
 
     schemas = factory.optimization_schemas_from_results(
-        results=qc_torsion_drive_results, combine=True
+        results=qc_torsion_drive_results, combine=True, processors=1
     )
 
     assert len(schemas) == 1

--- a/openff/bespokefit/utilities/__init__.py
+++ b/openff/bespokefit/utilities/__init__.py
@@ -1,7 +1,3 @@
-from openff.bespokefit.utilities.utilities import (
-    get_data_file_path,
-    get_molecule_cmiles,
-    temporary_cd,
-)
+from openff.bespokefit.utilities.utilities import get_data_file_path, temporary_cd
 
-__all__ = [get_data_file_path, get_molecule_cmiles, temporary_cd]
+__all__ = [get_data_file_path, temporary_cd]

--- a/openff/bespokefit/utilities/utilities.py
+++ b/openff/bespokefit/utilities/utilities.py
@@ -5,10 +5,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Optional, Union
 
-from openff.qcsubmit.common_structures import MoleculeAttributes
-from openff.qcsubmit.factories import BasicDatasetFactory
-from openff.toolkit.topology import Molecule
-
 
 def get_data_file_path(relative_path: str) -> str:
     """Get the full path to one of the files in the data directory.
@@ -79,11 +75,3 @@ def temporary_cd(directory_path: Optional[Union[str, Path]] = None):
 
     finally:
         os.chdir(old_directory)
-
-
-def get_molecule_cmiles(molecule: Molecule) -> MoleculeAttributes:
-    """
-    Generate the molecule cmiles data.
-    """
-    factory = BasicDatasetFactory()
-    return factory.create_cmiles_metadata(molecule)

--- a/openff/bespokefit/workflows/bespoke.py
+++ b/openff/bespokefit/workflows/bespoke.py
@@ -503,13 +503,13 @@ class BespokeWorkflowFactory(ClassBase):
                     optimization_schemas.append(schema)
         else:
             # run with 1 processor
-            for i, record_batch in tqdm.tqdm(
+            for record_batch, index in tqdm.tqdm(
                 sorted_records,
                 total=len(sorted_records),
                 ncols=80,
                 desc="Building Fitting Schema",
             ):
-                schema = self._optimization_schema_from_records(*record_batch)
+                schema = self._optimization_schema_from_records(record_batch, index)
                 optimization_schemas.append(schema)
 
         return optimization_schemas


### PR DESCRIPTION
## Description
This PR updates bespokefit to use the new `openff-fragmenter` package, this simply updates the imports and API calls.

The FragmentEngine attribute `fragmentation_engine` is also renamed to `type` as this is a literal that should not be changed.

## Status
- [ ] Ready to go