### PR TITLE
Add pydantic compatible custom numpy array type

### DIFF
--- a/openff/bespokefit/schema/bespoke/tasks.py
+++ b/openff/bespokefit/schema/bespoke/tasks.py
@@ -8,7 +8,6 @@ from openff.qcsubmit.datasets import DatasetEntry, OptimizationEntry, TorsionDri
 from openff.qcsubmit.factories import TorsiondriveDatasetFactory
 from openff.toolkit.topology import Molecule
 from pydantic import Field, validator
-from qcelemental.models.types import Array
 from qcportal.models import TorsionDriveRecord
 from qcportal.models.records import OptimizationRecord, RecordBase, ResultRecord
 from simtk import unit
@@ -16,6 +15,7 @@ from typing_extensions import Literal
 
 from openff.bespokefit.exceptions import DihedralSelectionError, MoleculeMissMatchError
 from openff.bespokefit.utilities.pydantic import SchemaBase
+from openff.bespokefit.utilities.typing import Array
 
 
 class BaseReferenceData(SchemaBase, abc.ABC):

--- a/openff/bespokefit/utilities/typing.py
+++ b/openff/bespokefit/utilities/typing.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+import numpy as np
+
+
+class ArrayMeta(type):
+    def __getitem__(self, t):
+        return type("Array", (Array,), {"__dtype__": t})
+
+
+class Array(np.ndarray, metaclass=ArrayMeta):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate_type
+
+    @classmethod
+    def validate_type(cls, val):
+
+        dtype = getattr(cls, "__dtype__", Any)
+
+        if dtype is Any:
+            return np.array(val)
+        else:
+            return np.array(val, dtype=dtype)


### PR DESCRIPTION
## Description

This PR adds a new custom array type for incorporating numpy arrays into pydantic models that replaces the QCElemental implementation. The QCElemental implementation attempts to modify the schema type but does not handle the case of an array of arrays leading to issues when exposing tasks via a RESTful API using FastAPI

## Status
- [X] Ready to go