### PR TITLE
ForceField generation clean up

### DIFF
--- a/openff/bespokefit/schema/results.py
+++ b/openff/bespokefit/schema/results.py
@@ -1,17 +1,12 @@
 import abc
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
-from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from pydantic import Field
 from typing_extensions import Literal
 
 from openff.bespokefit.exceptions import OptimizerError
-from openff.bespokefit.schema.bespoke.smirks import (
-    BespokeSmirksParameter,
-    BespokeTorsionSmirks,
-)
-from openff.bespokefit.schema.bespoke.tasks import TorsionTask
+from openff.bespokefit.schema.bespoke.smirks import BespokeSmirksParameter
 from openff.bespokefit.schema.fitting import (
     BespokeOptimizationSchema,
     OptimizationSchema,
@@ -19,9 +14,6 @@ from openff.bespokefit.schema.fitting import (
 )
 from openff.bespokefit.schema.smirnoff import SmirksType
 from openff.bespokefit.utilities.pydantic import SchemaBase
-
-if TYPE_CHECKING:
-    from openff.bespokefit.utilities.smirnoff import ForceFieldEditor
 
 OptimizationSchemaType = Union[OptimizationSchema, BespokeOptimizationSchema]
 
@@ -73,26 +65,14 @@ class BespokeOptimizationResults(BaseOptimizationResults):
 
     def get_final_force_field(
         self,
-        generate_bespoke_terms: bool = True,
         drop_out_value: Optional[float] = None,
     ) -> ForceField:
         """
         Generate the final bespoke forcefield for this molecule by collecting together
         all optimized smirks.
 
-        Note:
-            It is know that when creating fitting smirks for the fragments that they can
-            hit unintended dihedrals in other fragments if they are similar during
-            fitting. To ensure the correct parameters are used in their intended
-            positions on the parent molecule each fragment is typed with the fitting
-            force field and parameters again and a new bespoke term for the parent is
-            made which uses the same parameters.
-
         Parameters:
-            generate_bespoke_terms: If molecule specific bespoke terms should be made,
-                this is recommended as some fragment smirks patterns may not transfer
-                back to the parent correctly due to fragmentation.
-            drop_out_value: Any torsion force constants below this value will be dropped
+            drop_out_value: Any torsion force constants below this value will be set to 0
                 as they are probably negligible.
         """
         from openff.bespokefit.utilities.smirnoff import ForceFieldEditor
@@ -114,8 +94,6 @@ class BespokeOptimizationResults(BaseOptimizationResults):
 
         # get all of the target smirks
         target_smirks = self.final_smirks
-        # build the parent molecule
-        parent_molecule = self.input_schema.target_molecule.molecule
 
         if drop_out_value is not None:
             # loop over all of the target smirks and drop and torsion k values lower
@@ -123,16 +101,9 @@ class BespokeOptimizationResults(BaseOptimizationResults):
             for smirk in target_smirks:
 
                 if smirk.type == SmirksType.ProperTorsions:
-                    # keep a list of terms to remove
-                    to_remove = []
-
                     for p, term in smirk.terms.items():
                         if abs(float(term.k.split("*")[0])) < drop_out_value:
-                            to_remove.append(p)
-
-                    # now remove the low values
-                    for p in to_remove:
-                        del smirk.terms[p]
+                            term.k = 0
 
         # the final fitting force field should have all final smirks propagated through
         fitting_ff = ForceFieldEditor(
@@ -140,84 +111,4 @@ class BespokeOptimizationResults(BaseOptimizationResults):
         )
         fitting_ff.add_smirks(smirks=target_smirks, parameterize=False)
 
-        # here we type the fragment with the final forcefield and then build a bespoke
-        # dihedral term for the parent to hit the atoms that map from the fragment to
-        # the parent we do not modify any other smirks types but this needs testing to
-        # make sure that they do transfer.
-        if generate_bespoke_terms:
-            bespoke_smirks = []
-            # get a list of unique fragments and all of the torsions that have been
-            # targeted
-            for target in self.input_schema.targets:
-                if target.bespoke_task_type() == "torsion1d":
-                    for task in target.reference_data.tasks:
-                        # check if the smirks are from a fragment
-                        if task.fragment:
-                            new_smirks = self._generate_bespoke_torsions(
-                                force_field=fitting_ff,
-                                parent_molecule=parent_molecule,
-                                task_data=task,
-                            )
-                            bespoke_smirks.extend(new_smirks)
-
-            # make a new ff object with the new terms
-            bespoke_ff = ForceFieldEditor(
-                force_field_name=self.input_schema.initial_force_field
-            )
-            # get a list of non torsion smirks
-            new_smirks = [
-                smirk
-                for smirk in target_smirks
-                if smirk.type != SmirksType.ProperTorsions
-            ]
-            new_smirks.extend(bespoke_smirks)
-            bespoke_ff.add_smirks(smirks=new_smirks, parameterize=False)
-            return bespoke_ff.force_field
-
-        else:
-            return fitting_ff.force_field
-
-    def _generate_bespoke_torsions(
-        self,
-        force_field: "ForceFieldEditor",
-        parent_molecule: Molecule,
-        task_data: TorsionTask,
-    ) -> List[BespokeTorsionSmirks]:
-        """For the given task generate set of bespoke torsion terms for the parent
-        molecule using all layers. Here we have to type the fragment and use the fragment
-        parent mapping to transfer the parameters.
-        """
-        from openff.bespokefit.bespoke.smirks import SmirksGenerator
-
-        smirks_gen = SmirksGenerator(
-            target_smirks=[SmirksType.ProperTorsions],
-            layers="all",
-            expand_torsion_terms=False,
-        )
-
-        fragment = task_data.graph_molecule
-        fragment_parent_mapping = task_data.fragment_parent_mapping
-        # label the fitting molecule
-        labels = force_field.label_molecule(molecule=fragment)["ProperTorsions"]
-
-        bespoke_torsions = []
-        for bond in task_data.central_bonds:
-            fragment_dihedrals = smirks_gen.get_all_torsions(
-                bond=bond, molecule=fragment
-            )
-            for dihedral in fragment_dihedrals:
-                # get the smirk that hit this torsion
-                off_smirk = labels[dihedral]
-                # work out the parent torsion
-                parent_torsion = tuple([fragment_parent_mapping[i] for i in dihedral])
-                # make the bespoke smirks
-                smirks = smirks_gen._get_new_single_graph_smirks(
-                    atoms=parent_torsion, molecule=parent_molecule
-                )
-                # make the new Torsion Smirks
-                bespoke_smirk = BespokeTorsionSmirks(smirks=smirks)
-                bespoke_smirk.update_parameters(off_smirk=off_smirk)
-                if bespoke_smirk not in bespoke_torsions:
-                    bespoke_torsions.append(bespoke_smirk)
-
-        return bespoke_torsions
+        return fitting_ff.force_field

--- a/openff/bespokefit/tests/schema/test_results.py
+++ b/openff/bespokefit/tests/schema/test_results.py
@@ -2,6 +2,7 @@ import copy
 import os
 
 from openff.utilities import get_data_file_path
+from simtk import unit
 
 from openff.bespokefit.schema.fitting import Status
 from openff.bespokefit.schema.results import BespokeOptimizationResults
@@ -9,6 +10,9 @@ from openff.bespokefit.utilities.smirnoff import ForceFieldEditor
 
 
 def test_bespoke_get_final_force_field(bespoke_optimization_schema):
+    """
+    Make sure force constants bellow the drop out value are zeroed in the final force field.
+    """
 
     # TODO: This should be more comprehensively tested.
 
@@ -28,5 +32,7 @@ def test_bespoke_get_final_force_field(bespoke_optimization_schema):
         final_smirks=final_smirks,
     )
 
-    final_force_field = results.get_final_force_field(generate_bespoke_terms=False)
-    assert final_force_field is not None
+    final_force_field = results.get_final_force_field(drop_out_value=1)
+    assert final_force_field.get_parameter_handler("ProperTorsions")[
+        final_smirks[0].smirks
+    ].k1 == unit.Quantity(0, unit.kilocalorie_per_mole)

--- a/openff/bespokefit/utilities/smirnoff.py
+++ b/openff/bespokefit/utilities/smirnoff.py
@@ -115,6 +115,7 @@ class ForceFieldEditor:
             no_params = len(current_params)
             for i, parameter in enumerate(parameters, start=2):
                 smirk_data = parameter.to_off_smirks()
+                print(smirk_data)
                 if not parameterize:
                     del smirk_data["parameterize"]
                 # check if the parameter is new

--- a/openff/bespokefit/utilities/smirnoff.py
+++ b/openff/bespokefit/utilities/smirnoff.py
@@ -115,7 +115,6 @@ class ForceFieldEditor:
             no_params = len(current_params)
             for i, parameter in enumerate(parameters, start=2):
                 smirk_data = parameter.to_off_smirks()
-                print(smirk_data)
                 if not parameterize:
                     del smirk_data["parameterize"]
                 # check if the parameter is new


### PR DESCRIPTION
## Description
This PR simplifies the generation of the final forcefield after fitting new bespoke parameters. The old method is now redundant as the new smirks generation method ensures that the parameters are correctly transferred back from the fragment to the parent. We also now just zero out values below the drop out threshold rather than removing them. 

## Status
- [x] Ready to go