### PR TITLE
Add support for supplying local QC data

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -41,3 +41,6 @@ dependencies:
   - chemper
   - basis_set_exchange
   - torsiondrive
+
+  - pip:
+      - git+git://github.com/MolSSI/QCEngine.git  # Needed until release with TD made.

--- a/devtools/conda-envs/xtb.yaml
+++ b/devtools/conda-envs/xtb.yaml
@@ -43,3 +43,6 @@ dependencies:
   - chemper
   - basis_set_exchange
   - torsiondrive
+
+  - pip:
+      - git+git://github.com/MolSSI/QCEngine.git  # Needed until release with TD made.

--- a/openff/bespokefit/schema/data.py
+++ b/openff/bespokefit/schema/data.py
@@ -12,8 +12,7 @@ from openff.qcsubmit.datasets import (
 from openff.toolkit.topology import Molecule
 from pydantic import Field, PositiveInt, validator
 from pydantic.generics import GenericModel
-from qcelemental.models import AtomicResult, DriverEnum, OptimizationResult
-from qcelemental.models.procedures import TorsionDriveResult
+from qcelemental.models import DriverEnum
 from qcportal.models import OptimizationRecord, ResultRecord, TorsionDriveRecord
 from typing_extensions import Literal
 
@@ -224,19 +223,3 @@ class LocalQCData(GenericModel, Generic[QCDataType]):
     type: Literal["local"] = "local"
 
     qc_records: List[QCDataType] = Field(..., description="A list of local QC results.")
-
-    @validator("qc_records", each_item=True)
-    def validate(cls, v):
-
-        # This seems to be needed to stop pydantic accidentally using this validator
-        # for these other types...
-        if isinstance(v, BespokeQCData):
-            return v
-
-        assert "canonical_isomeric_explicit_hydrogen_mapped_smiles" in v.extras, (
-            "each result must contain an "
-            "`canonical_isomeric_explicit_hydrogen_mapped_smiles` "
-            "entry in the results `extras` field"
-        )
-
-        return v

--- a/openff/bespokefit/schema/data.py
+++ b/openff/bespokefit/schema/data.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, Generic, List, Optional, Tuple, TypeVar, Union
 
 from openff.qcsubmit.common_structures import QCSpec
 from openff.qcsubmit.datasets import (
@@ -11,7 +11,9 @@ from openff.qcsubmit.datasets import (
 )
 from openff.toolkit.topology import Molecule
 from pydantic import Field, PositiveInt, validator
-from qcelemental.models import DriverEnum
+from pydantic.generics import GenericModel
+from qcelemental.models import AtomicResult, DriverEnum, OptimizationResult
+from qcelemental.models.procedures import TorsionDriveResult
 from qcportal.models import OptimizationRecord, ResultRecord, TorsionDriveRecord
 from typing_extensions import Literal
 
@@ -22,6 +24,8 @@ from openff.bespokefit.exceptions import (
 )
 from openff.bespokefit.schema.bespoke.tasks import FittingTask
 from openff.bespokefit.utilities.pydantic import SchemaBase
+
+QCDataType = TypeVar("QCDataType")
 
 
 class BespokeQCData(SchemaBase):
@@ -213,3 +217,26 @@ class BespokeQCData(SchemaBase):
                 hash_map.setdefault(task_hash, []).append(task)
 
         return hash_map
+
+
+class LocalQCData(GenericModel, Generic[QCDataType]):
+
+    type: Literal["local"] = "local"
+
+    qc_records: List[QCDataType] = Field(..., description="A list of local QC results.")
+
+    @validator("qc_records", each_item=True)
+    def validate(cls, v):
+
+        # This seems to be needed to stop pydantic accidentally using this validator
+        # for these other types...
+        if isinstance(v, BespokeQCData):
+            return v
+
+        assert "canonical_isomeric_explicit_hydrogen_mapped_smiles" in v.extras, (
+            "each result must contain an "
+            "`canonical_isomeric_explicit_hydrogen_mapped_smiles` "
+            "entry in the results `extras` field"
+        )
+
+        return v

--- a/openff/bespokefit/schema/targets.py
+++ b/openff/bespokefit/schema/targets.py
@@ -7,9 +7,11 @@ from openff.qcsubmit.results import (
     TorsionDriveResultCollection,
 )
 from pydantic import Field, PositiveFloat, validator
+from qcelemental.models import AtomicResult
+from qcelemental.models.procedures import OptimizationResult, TorsionDriveResult
 from typing_extensions import Literal
 
-from openff.bespokefit.schema.data import BespokeQCData
+from openff.bespokefit.schema.data import BespokeQCData, LocalQCData
 from openff.bespokefit.utilities.pydantic import SchemaBase
 
 
@@ -20,7 +22,7 @@ class BaseTargetSchema(SchemaBase, abc.ABC):
         1.0, description="The amount to weight the target by."
     )
 
-    reference_data: Optional[Union[Any, BespokeQCData]]
+    reference_data: Optional[Union[Any, LocalQCData[Any], BespokeQCData]]
 
     extras: Dict[str, str] = Field(
         {},
@@ -58,7 +60,9 @@ class TorsionProfileTargetSchema(BaseTargetSchema):
     type: Literal["TorsionProfile"] = "TorsionProfile"
 
     reference_data: Optional[
-        Union[TorsionDriveResultCollection, BespokeQCData]
+        Union[
+            LocalQCData[TorsionDriveResult], BespokeQCData, TorsionDriveResultCollection
+        ]
     ] = Field(
         None,
         description="The reference QC data (either existing or to be generated on the "
@@ -85,7 +89,9 @@ class AbInitioTargetSchema(BaseTargetSchema):
     type: Literal["AbInitio"] = "AbInitio"
 
     reference_data: Optional[
-        Union[TorsionDriveResultCollection, BespokeQCData]
+        Union[
+            LocalQCData[TorsionDriveResult], BespokeQCData, TorsionDriveResultCollection
+        ]
     ] = Field(
         None,
         description="The reference QC data (either existing or to be generated on the "
@@ -114,7 +120,9 @@ class VibrationTargetSchema(BaseTargetSchema):
 
     type: Literal["Vibration"] = "Vibration"
 
-    reference_data: Optional[Union[BasicResultCollection, BespokeQCData]] = Field(
+    reference_data: Optional[
+        Union[LocalQCData[AtomicResult], BespokeQCData, BasicResultCollection]
+    ] = Field(
         None,
         description="The reference QC data (either existing or to be generated on the "
         "fly) to fit against.",
@@ -135,7 +143,9 @@ class OptGeoTargetSchema(BaseTargetSchema):
     type: Literal["OptGeo"] = "OptGeo"
 
     reference_data: Optional[
-        Union[OptimizationResultCollection, BespokeQCData]
+        Union[
+            LocalQCData[OptimizationResult], BespokeQCData, OptimizationResultCollection
+        ]
     ] = Field(
         None,
         description="The reference QC data (either existing or to be generated on the "

--- a/openff/bespokefit/tests/optimizers/forcebalance/test_factories.py
+++ b/openff/bespokefit/tests/optimizers/forcebalance/test_factories.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 from openff.toolkit.topology import Molecule
 from openff.utilities import temporary_cd
-from qcportal.models import OptimizationRecord, ResultRecord, TorsionDriveRecord
 
 from openff.bespokefit.optimizers.forcebalance.factories import (
     AbInitioTargetFactory,
@@ -50,10 +49,13 @@ def read_qdata(qdata_file: str) -> Tuple[List[np.array], List[float], List[np.ar
     return coords, energies, gradients
 
 
+@pytest.mark.parametrize(
+    "result_fixture", ["qc_torsion_drive_record", "qc_torsion_drive_qce_result"]
+)
 @pytest.mark.parametrize("with_gradients", [False, True])
-def test_generate_ab_initio_target(
-    qc_torsion_drive_record: Tuple[TorsionDriveRecord, Molecule], with_gradients
-):
+def test_generate_ab_initio_target(result_fixture, with_gradients, request):
+
+    qc_torsion_drive_record = request.getfixturevalue(result_fixture)
 
     with temporary_cd():
 
@@ -105,9 +107,12 @@ def test_generate_ab_initio_target(
         #         assert coord == data.molecule.geometry.flatten().tolist()
 
 
-def test_generate_torsion_target(
-    qc_torsion_drive_record: Tuple[TorsionDriveRecord, Molecule]
-):
+@pytest.mark.parametrize(
+    "result_fixture", ["qc_torsion_drive_record", "qc_torsion_drive_qce_result"]
+)
+def test_generate_torsion_target(result_fixture, request):
+
+    qc_torsion_drive_record = request.getfixturevalue(result_fixture)
 
     with temporary_cd():
 
@@ -139,9 +144,12 @@ def test_generate_torsion_target(
         assert "energy_upper_limit" in metadata
 
 
-def test_generate_optimization_target(
-    qc_optimization_record: Tuple[OptimizationRecord, Molecule]
-):
+@pytest.mark.parametrize(
+    "result_fixture", ["qc_optimization_record", "qc_optimization_qce_result"]
+)
+def test_generate_optimization_target(result_fixture, request):
+
+    qc_optimization_record = request.getfixturevalue(result_fixture)
 
     with temporary_cd():
 
@@ -159,8 +167,12 @@ def test_generate_optimization_target(
         assert os.path.isfile("optgeo_options.txt")
 
 
-def test_opt_geo_batching(qc_optimization_record: ResultRecord):
+@pytest.mark.parametrize(
+    "result_fixture", ["qc_optimization_record", "qc_optimization_qce_result"]
+)
+def test_opt_geo_batching(result_fixture, request):
 
+    qc_optimization_record = request.getfixturevalue(result_fixture)
     qc_records = [qc_optimization_record] * 120
 
     target_batches = OptGeoTargetFactory._batch_qc_records(
@@ -186,7 +198,13 @@ def test_opt_geo_target_section():
     assert "batch_size" in target_schema.extras
 
 
-def test_generate_vibration_target(qc_hessian_record: Tuple[ResultRecord, Molecule]):
+@pytest.mark.parametrize(
+    "result_fixture", ["qc_hessian_record", "qc_hessian_qce_result"]
+)
+def test_generate_vibration_target(result_fixture, request):
+
+    qc_hessian_record = request.getfixturevalue(result_fixture)
+
     with temporary_cd():
 
         VibrationTargetFactory._generate_target(

--- a/openff/bespokefit/tests/optimizers/forcebalance/test_factories.py
+++ b/openff/bespokefit/tests/optimizers/forcebalance/test_factories.py
@@ -162,7 +162,13 @@ def test_generate_optimization_target(result_fixture, request):
         )
 
         for (index, extension) in itertools.product([0, 1], ["xyz", "sdf", "pdb"]):
-            assert os.path.isfile(f"{qc_optimization_record[0].id}-{index}.{extension}")
+
+            qc_record_id = (
+                qc_optimization_record[0].extras["id"]
+                if "id" in qc_optimization_record[0].extras
+                else qc_optimization_record[0].id
+            )
+            assert os.path.isfile(f"{qc_record_id}-{index}.{extension}")
 
         assert os.path.isfile("optgeo_options.txt")
 

--- a/openff/bespokefit/tests/schema/test_data.py
+++ b/openff/bespokefit/tests/schema/test_data.py
@@ -134,33 +134,3 @@ def test_get_task_map(ethane_bespoke_data):
 
     task_map = ethane_bespoke_data.get_task_map()
     assert len(task_map) == 1
-
-
-def test_validate_local_data_entries():
-    class MockQCResult(BaseModel):
-        extras: Dict[str, Any] = Field(dict())
-
-    local_data = LocalQCData(
-        qc_records=[
-            MockQCResult(
-                extras={
-                    "canonical_isomeric_explicit_hydrogen_mapped_smiles": "[Cl:1][H:2]"
-                }
-            )
-        ]
-    )
-    assert len(local_data.qc_records) == 1
-
-    with pytest.raises(
-        ValidationError, match="canonical_isomeric_explicit_hydrogen_mapped_smiles"
-    ):
-        LocalQCData(
-            qc_records=[
-                MockQCResult(
-                    extras={
-                        "canonical_isomeric_explicit_hydrogen_mapped_smiles": "[Cl:1][H:2]"
-                    }
-                ),
-                MockQCResult(),
-            ]
-        )

--- a/openff/bespokefit/tests/schema/test_data.py
+++ b/openff/bespokefit/tests/schema/test_data.py
@@ -1,10 +1,7 @@
-from typing import Any, Dict
-
 import pytest
 from openff.qcsubmit.common_structures import MoleculeAttributes
 from openff.qcsubmit.datasets import TorsiondriveDataset, TorsionDriveEntry
 from openff.toolkit.topology import Molecule
-from pydantic import BaseModel, Field, ValidationError
 from simtk import unit
 
 from openff.bespokefit.exceptions import DihedralSelectionError, MoleculeMissMatchError
@@ -13,7 +10,7 @@ from openff.bespokefit.schema.bespoke.tasks import (
     TorsionTask,
     TorsionTaskReferenceData,
 )
-from openff.bespokefit.schema.data import BespokeQCData, LocalQCData
+from openff.bespokefit.schema.data import BespokeQCData
 from openff.bespokefit.tests import does_not_raise
 
 


### PR DESCRIPTION
## Description

This PR adds a new `LocalQCData` type that allows users to pass QC data generated using QCEngine directly to an input schema.

## Status
- [X] Ready to go