### PR TITLE
Expose the default QC specs used by the bespoke factory

### DIFF
--- a/openff/bespokefit/tests/workflows/test_bespoke.py
+++ b/openff/bespokefit/tests/workflows/test_bespoke.py
@@ -4,6 +4,7 @@ Test for the bespoke-fit workflow generator.
 import os
 
 import pytest
+from openff.qcsubmit.common_structures import QCSpec
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from openff.utilities import get_data_file_path, temporary_cd
@@ -252,3 +253,11 @@ def test_optimization_schemas_from_results(qc_torsion_drive_results):
     )
 
     assert len(schemas) == 1
+
+
+def test_select_qc_spec():
+
+    default_qc_spec = QCSpec(program="rdkit", method="uff", basis=None)
+
+    factory = BespokeWorkflowFactory(default_qc_specs=[default_qc_spec])
+    assert factory._select_qc_spec(Molecule.from_smiles("C")) == default_qc_spec


### PR DESCRIPTION
## Description

This adds an options to configure the default QC spec(s). Currently this is limited to a single QC spec and no validation is performed to ensure compatibility with the molecule. 

This functionality will be expanded in a future PR to include more rigorous validation + selection of a spec from multiple options.

## Status
- [X] Ready to go