### PR TITLE
Fix executor models cannot serialize numpy

### DIFF
--- a/openff/bespokefit/executor/services/coordinator/models.py
+++ b/openff/bespokefit/executor/services/coordinator/models.py
@@ -1,11 +1,12 @@
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from openff.bespokefit.executor.services.coordinator.stages import StageType
 from openff.bespokefit.executor.utilities.typing import Status
 from openff.bespokefit.schema.fitting import BespokeOptimizationSchema
 from openff.bespokefit.schema.results import BespokeOptimizationResults
+from openff.bespokefit.utilities.pydantic import BaseModel
 
 
 class CoordinatorGETStageStatus(BaseModel):

--- a/openff/bespokefit/executor/services/fragmenter/models.py
+++ b/openff/bespokefit/executor/services/fragmenter/models.py
@@ -5,9 +5,10 @@ from openff.fragmenter.fragment import (
     PfizerFragmenter,
     WBOFragmenter,
 )
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from openff.bespokefit.executor.utilities.typing import Status
+from openff.bespokefit.utilities.pydantic import BaseModel
 
 
 class FragmenterBaseResponse(BaseModel):

--- a/openff/bespokefit/executor/services/optimizer/models.py
+++ b/openff/bespokefit/executor/services/optimizer/models.py
@@ -1,10 +1,11 @@
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from openff.bespokefit.executor.utilities.typing import Status
 from openff.bespokefit.schema.fitting import BespokeOptimizationSchema
 from openff.bespokefit.schema.results import BespokeOptimizationResults
+from openff.bespokefit.utilities.pydantic import BaseModel
 
 
 class OptimizerBaseResponse(BaseModel):

--- a/openff/bespokefit/executor/services/qcgenerator/models.py
+++ b/openff/bespokefit/executor/services/qcgenerator/models.py
@@ -1,12 +1,13 @@
 from typing import Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 from qcelemental.models import AtomicResult, FailedOperation, OptimizationResult
 from qcengine.procedures.torsiondrive import TorsionDriveResult
 from typing_extensions import Literal
 
 from openff.bespokefit.executor.utilities.typing import Status
 from openff.bespokefit.schema.tasks import HessianTask, OptimizationTask, Torsion1DTask
+from openff.bespokefit.utilities.pydantic import BaseModel
 
 
 class QCGeneratorBaseResponse(BaseModel):

--- a/openff/bespokefit/utilities/pydantic.py
+++ b/openff/bespokefit/utilities/pydantic.py
@@ -1,7 +1,14 @@
 """A set of common utilities and types useful for building pydantic models.
 """
 import numpy as np
-from pydantic import BaseModel
+import pydantic
+
+
+class BaseModel(pydantic.BaseModel):
+    """The base model from which all data models within the package should inherit."""
+
+    class Config:
+        json_encoders = {np.ndarray: lambda v: v.flatten().tolist()}
 
 
 class SchemaBase(BaseModel):
@@ -11,8 +18,6 @@ class SchemaBase(BaseModel):
 
         allow_mutation = True
         validate_assignment = True
-
-        json_encoders = {np.ndarray: lambda v: v.flatten().tolist()}
 
 
 class ClassBase(SchemaBase):


### PR DESCRIPTION
## Description

This PR fixes a bug whereby the executor response models did not register the custom numpy encoder, and hence could not be dumped to JSON.

## Status
- [X] Ready to go