### PR TITLE
Add simple caching to QC generator service

### DIFF
--- a/openff/bespokefit/executor/services/qcgenerator/cache.py
+++ b/openff/bespokefit/executor/services/qcgenerator/cache.py
@@ -1,10 +1,53 @@
 import hashlib
-from typing import Union
+from typing import TypeVar, Union
 
 import redis
+from openff.toolkit.topology import Molecule
 
 from openff.bespokefit.executor.services.qcgenerator import worker
 from openff.bespokefit.schema.tasks import HessianTask, OptimizationTask, Torsion1DTask
+from openff.bespokefit.utilities.molecule import canonical_order_atoms
+
+_T = TypeVar("_T", HessianTask, OptimizationTask, Torsion1DTask)
+
+
+def _canonicalize_task(task: _T) -> _T:
+
+    task = task.copy(deep=True)
+
+    # Ensure the SMILES has a canonical ordering to help ensure cache hits.
+    canonical_molecule = canonical_order_atoms(
+        Molecule.from_smiles(task.smiles, allow_undefined_stereo=True)
+    )
+
+    if isinstance(task, Torsion1DTask):
+
+        map_to_atom_index = {
+            j: i for i, j in canonical_molecule.properties["atom_map"].items()
+        }
+
+        central_atom_indices = sorted(
+            map_to_atom_index[task.central_bond[i]] for i in (0, 1)
+        )
+        canonical_molecule.properties["atom_map"] = {
+            atom_index: (i + 1) for i, atom_index in enumerate(central_atom_indices)
+        }
+
+        canonical_smiles = canonical_molecule.to_smiles(
+            isomeric=True, explicit_hydrogens=True, mapped=True
+        )
+
+        task.central_bond = (1, 2)
+
+    else:
+
+        canonical_smiles = canonical_molecule.to_smiles(
+            isomeric=True, explicit_hydrogens=True, mapped=False
+        )
+
+    task.smiles = canonical_smiles
+
+    return task
 
 
 def cached_compute_task(
@@ -23,6 +66,9 @@ def cached_compute_task(
         compute = worker.compute_hessian
     else:
         raise NotImplementedError()
+
+    # Canonicalize the task to improve the cache hit rate.
+    task = _canonicalize_task(task)
 
     task_hash = hashlib.sha512(task.json().encode()).hexdigest()
     task_id = redis_connection.hget("qcgenerator:task-ids", task_hash)

--- a/openff/bespokefit/executor/services/qcgenerator/cache.py
+++ b/openff/bespokefit/executor/services/qcgenerator/cache.py
@@ -1,0 +1,39 @@
+import hashlib
+from typing import Union
+
+import redis
+
+from openff.bespokefit.executor.services.qcgenerator import worker
+from openff.bespokefit.schema.tasks import HessianTask, OptimizationTask, Torsion1DTask
+
+
+def cached_compute_task(
+    task: Union[HessianTask, OptimizationTask, Torsion1DTask],
+    redis_connection: redis.Redis,
+) -> str:
+    """Checks to see if a QC task has already been executed and if not send it to a
+    worker.
+    """
+
+    if isinstance(task, Torsion1DTask):
+        compute = worker.compute_torsion_drive
+    elif isinstance(task, OptimizationTask):
+        compute = worker.compute_optimization
+    elif isinstance(task, HessianTask):
+        compute = worker.compute_hessian
+    else:
+        raise NotImplementedError()
+
+    task_hash = hashlib.sha512(task.json().encode()).hexdigest()
+    task_id = redis_connection.hget("qcgenerator:task-ids", task_hash)
+
+    if task_id is not None:
+        return task_id.decode()
+
+    task_id = compute.delay(task_json=task.json()).id
+
+    redis_connection.hset("qcgenerator:types", task_id, task.type)
+    # Make sure to only set the hash after the type is set in case the connection
+    # goes down before this information is entered and subsequently discarded.
+    redis_connection.hset("qcgenerator:task-ids", task_hash, task_id)
+    return task_id

--- a/openff/bespokefit/tests/executor/mocking/celery.py
+++ b/openff/bespokefit/tests/executor/mocking/celery.py
@@ -6,7 +6,7 @@ from celery.result import AsyncResult
 
 
 def mock_celery_task(
-    worker_module: ModuleType, function_name: str, monkeypatch
+    worker_module: ModuleType, function_name: str, monkeypatch, task_id: str = "1"
 ) -> Dict[str, Any]:
 
     submitted_task_kwargs: Dict[str, Any] = {}
@@ -14,7 +14,7 @@ def mock_celery_task(
     def _mock_celery_task_delay(**kwargs):
 
         submitted_task_kwargs.update(kwargs)
-        return namedtuple("MockReturn", "id")("1")
+        return namedtuple("MockReturn", "id")(task_id)
 
     def _mock_celery_task():
         pass

--- a/openff/bespokefit/tests/executor/services/qcgenerator/test_app.py
+++ b/openff/bespokefit/tests/executor/services/qcgenerator/test_app.py
@@ -10,6 +10,7 @@ from qcelemental.models.common_models import Model, Provenance
 
 from openff.bespokefit.executor.services.qcgenerator import worker
 from openff.bespokefit.executor.services.qcgenerator.app import _retrieve_qc_result
+from openff.bespokefit.executor.services.qcgenerator.cache import _canonicalize_task
 from openff.bespokefit.executor.services.qcgenerator.models import (
     QCGeneratorGETResponse,
     QCGeneratorPOSTBody,
@@ -154,7 +155,7 @@ def test_post_qc_result(
     )
     request.raise_for_status()
 
-    assert submitted_task_kwargs["task_json"] == task.json()
+    assert submitted_task_kwargs["task_json"] == _canonicalize_task(task).json()
     assert redis_connection.hget("qcgenerator:types", "1").decode() == task.type
 
     result = QCGeneratorPOSTResponse.parse_raw(request.text)

--- a/openff/bespokefit/tests/executor/services/qcgenerator/test_cache.py
+++ b/openff/bespokefit/tests/executor/services/qcgenerator/test_cache.py
@@ -1,0 +1,52 @@
+import pytest
+from qcelemental.models.common_models import Model
+
+from openff.bespokefit.executor.services.qcgenerator import worker
+from openff.bespokefit.executor.services.qcgenerator.cache import cached_compute_task
+from openff.bespokefit.schema.tasks import HessianTask, OptimizationTask, Torsion1DTask
+from openff.bespokefit.tests.executor.mocking.celery import mock_celery_task
+
+
+@pytest.mark.parametrize(
+    "task, compute_function",
+    [
+        (
+            Torsion1DTask(
+                smiles="[CH2:1][CH2:2]",
+                central_bond=(1, 2),
+                program="rdkit",
+                model=Model(method="uff", basis=None),
+            ),
+            "compute_torsion_drive",
+        ),
+        (
+            OptimizationTask(
+                smiles="[CH2:1][CH2:2]",
+                n_conformers=1,
+                program="rdkit",
+                model=Model(method="uff", basis=None),
+            ),
+            "compute_optimization",
+        ),
+        (
+            HessianTask(
+                smiles="[CH2:1][CH2:2]",
+                program="rdkit",
+                model=Model(method="uff", basis=None),
+            ),
+            "compute_hessian",
+        ),
+    ],
+)
+def test_cached_compute_task(
+    qcgenerator_client, redis_connection, monkeypatch, task, compute_function
+):
+
+    mock_celery_task(worker, compute_function, monkeypatch, "task-1")
+
+    task_id = cached_compute_task(task, redis_connection)
+    assert redis_connection.hget("qcgenerator:types", "task-1").decode() == task.type
+
+    mock_celery_task(worker, compute_function, monkeypatch, "task-2")
+
+    assert cached_compute_task(task, redis_connection) == task_id

--- a/openff/bespokefit/tests/executor/services/qcgenerator/test_cache.py
+++ b/openff/bespokefit/tests/executor/services/qcgenerator/test_cache.py
@@ -2,9 +2,26 @@ import pytest
 from qcelemental.models.common_models import Model
 
 from openff.bespokefit.executor.services.qcgenerator import worker
-from openff.bespokefit.executor.services.qcgenerator.cache import cached_compute_task
+from openff.bespokefit.executor.services.qcgenerator.cache import (
+    _canonicalize_task,
+    cached_compute_task,
+)
 from openff.bespokefit.schema.tasks import HessianTask, OptimizationTask, Torsion1DTask
 from openff.bespokefit.tests.executor.mocking.celery import mock_celery_task
+
+
+def test_canonicalize_torsion_task():
+
+    original_task = Torsion1DTask(
+        smiles="[H:1][C:2]([H:3])([H:4])[O:5][H:6]",
+        central_bond=(2, 5),
+        program="rdkit",
+        model=Model(method="uff", basis=None),
+    )
+    canonical_task = _canonicalize_task(original_task)
+
+    assert canonical_task.smiles == "[H][C:1]([H])([H])[O:2][H]"
+    assert canonical_task.central_bond == (1, 2)
 
 
 @pytest.mark.parametrize(

--- a/openff/bespokefit/tests/utilities/test_molecule.py
+++ b/openff/bespokefit/tests/utilities/test_molecule.py
@@ -1,22 +1,72 @@
+import importlib
+import sys
+
 import pytest
 from openff.toolkit.topology import Molecule
 
 from openff.bespokefit.utilities.molecule import (
+    _oe_canonical_atom_order,
     _oe_get_atom_symmetries,
+    _rd_canonical_atom_order,
     _rd_get_atom_symmetries,
+    canonical_order_atoms,
     get_atom_symmetries,
     get_torsion_indices,
     group_valence_by_symmetry,
 )
 
 
+@pytest.fixture()
+def with_oe_backend(monkeypatch):
+
+    oechem = pytest.importorskip("openeye.oechem")
+
+    if not oechem.OEChemIsLicensed():
+        pytest.skip("OE is not licensed")
+
+    monkeypatch.setitem(sys.modules, "rdkit", None)
+
+
+@pytest.fixture()
+def with_rd_backend(monkeypatch):
+
+    pytest.importorskip("rdkit")
+    monkeypatch.setitem(sys.modules, "openeye", None)
+    monkeypatch.setitem(sys.modules, "openeye.oechem", None)
+
+
+def test_oe_fixture(with_oe_backend):
+    """Ensure that our fixture really does ensure only OE can be used"""
+
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("rdkit")
+
+
 @pytest.mark.parametrize(
-    "get_symmetries",
-    [_oe_get_atom_symmetries, _rd_get_atom_symmetries, get_atom_symmetries],
+    "module, package",
+    [("openeye", None), ("openeye.oechem", None), ("openeye", "oechem")],
 )
-def test_get_atom_symmetries(get_symmetries):
+def test_rd_fixture(with_rd_backend, module, package):
+    """Ensure that our fixture really does ensure only RDKit can be used"""
+
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module(module, package)
+
+
+@pytest.mark.parametrize(
+    "get_symmetries, backend",
+    [
+        (_oe_get_atom_symmetries, "with_oe_backend"),
+        (_rd_get_atom_symmetries, "with_rd_backend"),
+        (get_atom_symmetries, "with_oe_backend"),
+        (get_atom_symmetries, "with_rd_backend"),
+    ],
+)
+def test_get_atom_symmetries(get_symmetries, backend, request):
 
     molecule = Molecule.from_mapped_smiles("[H:1][C:2]([H:3])([H:4])[O:5][H:6]")
+
+    request.getfixturevalue(backend)
 
     try:
         atom_symmetries = get_symmetries(molecule)
@@ -28,6 +78,48 @@ def test_get_atom_symmetries(get_symmetries):
 
     assert len({atom_symmetries[i] for i in (0, 2, 3)}) == 1
     assert len({atom_symmetries[i] for i in (1, 4, 5)}) == 3
+
+
+@pytest.mark.parametrize(
+    "canonical_order_func",
+    [_oe_canonical_atom_order, _rd_canonical_atom_order],
+)
+def test_canonical_atom_order(canonical_order_func):
+
+    molecule = Molecule.from_mapped_smiles("[H:1][C:2]([H:3])([H:4])[O:5][H:6]")
+
+    try:
+        atom_order = canonical_order_func(molecule)
+
+    except ModuleNotFoundError as e:
+
+        pytest.skip(f"missing optional dependency - {e.name}")
+        return
+
+    # In general the canonical order should have H ranked first and heavy atoms last.
+    assert sorted(atom_order[i] for i in [0, 2, 3, 5]) == [0, 1, 2, 3]
+    assert sorted(atom_order[i] for i in [1, 4]) == [4, 5]
+
+
+@pytest.mark.parametrize("backend", ["with_rd_backend", "with_oe_backend"])
+def test_canonical_order_atoms(backend, request):
+
+    molecule = Molecule.from_mapped_smiles("[H:1][C:2]([H:3])([H:4])[O:5][H:6]")
+    molecule.properties["atom_map"] = {i: i + 1 for i in range(molecule.n_atoms)}
+
+    request.getfixturevalue(backend)
+
+    canonical_molecule = canonical_order_atoms(molecule)
+    assert [a.atomic_number for a in canonical_molecule.atoms] in (
+        [6, 8, 1, 1, 1, 1],
+        [8, 6, 1, 1, 1, 1],
+    )
+
+    canonical_atom_map = canonical_molecule.properties["atom_map"]
+
+    # Make sure the atom map has been updated to reflect that the heavy atoms are now at
+    # the beginning of the molecule
+    assert (canonical_atom_map[0], canonical_atom_map[1]) in [(2, 5), (5, 2)]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

This PR adds a simple caching system to the QC generator service whereby the redis backend now tracks a 'task hash -> task id' map.

This can be extended as needed in future to include checks of locally cached QC data stored in QCSubmit result collections.

## Notes

* This PR adds functions to canonicalize a molecule in a way that preserves the original atom map. These, and the whole `molecule` utility file need to be upstreamed to the TK at some point

## Status
- [X] Ready to go