### PR TITLE
Improve resilience of celery tasks

### DIFF
--- a/devtools/conda-envs/basic.yaml
+++ b/devtools/conda-envs/basic.yaml
@@ -45,7 +45,7 @@ dependencies:
   - fastapi
   - celery
   - httpx
-  - redis
+  - redis-server
   - redis-py
 
     ### Testing

--- a/devtools/conda-envs/xtb.yaml
+++ b/devtools/conda-envs/xtb.yaml
@@ -45,7 +45,7 @@ dependencies:
   - fastapi
   - celery
   - httpx
-  - redis
+  - redis-server
   - redis-py
 
     ### Testing

--- a/openff/bespokefit/executor/services/fragmenter/worker.py
+++ b/openff/bespokefit/executor/services/fragmenter/worker.py
@@ -15,7 +15,7 @@ redis_connection = redis.Redis(
 celery_app = configure_celery_app("fragmenter", redis_connection)
 
 
-@celery_app.task
+@celery_app.task(acks_late=True)
 def fragment(cmiles: str, fragmenter_json: str, target_bond_smarts: List[str]) -> str:
 
     from openff.toolkit.topology import Molecule

--- a/openff/bespokefit/executor/services/qcgenerator/worker.py
+++ b/openff/bespokefit/executor/services/qcgenerator/worker.py
@@ -28,7 +28,7 @@ redis_connection = redis.Redis(
 celery_app = configure_celery_app("qcgenerator", redis_connection)
 
 
-@celery_app.task
+@celery_app.task(acks_late=True)
 def compute_torsion_drive(task_json: str) -> TorsionDriveResult:
     """Runs a torsion drive using QCEngine."""
 

--- a/openff/bespokefit/executor/utilities/celery.py
+++ b/openff/bespokefit/executor/utilities/celery.py
@@ -49,9 +49,7 @@ def configure_celery_app(
 
     celery_app.conf.task_track_started = True
     celery_app.conf.task_default_queue = app_name
-    celery_app.conf.broker_transport_options = {
-        'visibility_timeout': 1000000
-    }
+    celery_app.conf.broker_transport_options = {"visibility_timeout": 1000000}
 
     return celery_app
 

--- a/openff/bespokefit/executor/utilities/celery.py
+++ b/openff/bespokefit/executor/utilities/celery.py
@@ -49,6 +49,9 @@ def configure_celery_app(
 
     celery_app.conf.task_track_started = True
     celery_app.conf.task_default_queue = app_name
+    celery_app.conf.broker_transport_options = {
+        'visibility_timeout': 1000000
+    }
 
     return celery_app
 


### PR DESCRIPTION
## Description

This PR attempts to improve the resilience of celery tasks by acknowledging late. This ensures tasks are passed to other worker if a worker is killed while running a task.

This change requires tasks to be idempotent from this point forward.

## Status
- [X] Ready to go