### PR TITLE
Clean-up executor processes in set order

### DIFF
--- a/openff/bespokefit/executor/utilities/celery.py
+++ b/openff/bespokefit/executor/utilities/celery.py
@@ -61,11 +61,14 @@ def _spawn_worker(celery_app, concurrency: int = 1):
         loglevel="INFO",
         logfile=f"celery-{celery_app.main}.log",
         quiet=True,
+        hostname=celery_app.main,
     )
     worker.start()
 
 
-def spawn_worker(celery_app, concurrency: int = 1, asynchronous: bool = True):
+def spawn_worker(
+    celery_app, concurrency: int = 1, asynchronous: bool = True
+) -> Optional[multiprocessing.Process]:
 
     if concurrency < 1:
         return
@@ -76,6 +79,8 @@ def spawn_worker(celery_app, concurrency: int = 1, asynchronous: bool = True):
             target=_spawn_worker, args=(celery_app, concurrency), daemon=True
         )
         worker_process.start()
+
+        return worker_process
 
     else:
 

--- a/openff/bespokefit/executor/utilities/redis.py
+++ b/openff/bespokefit/executor/utilities/redis.py
@@ -1,5 +1,6 @@
 import atexit
 import functools
+import os
 import shlex
 import shutil
 import subprocess
@@ -35,7 +36,8 @@ def launch_redis(
     stdout_file: Optional[Union[IO, int]] = None,
     directory: Optional[str] = None,
     persistent: bool = True,
-):
+    terminate_at_exit: bool = True,
+) -> subprocess.Popen:
 
     redis_server_path = shutil.which("redis-server")
 
@@ -69,9 +71,14 @@ def launch_redis(
         )
 
     redis_process = subprocess.Popen(
-        shlex.split(redis_command), stderr=stderr_file, stdout=stdout_file
+        shlex.split(redis_command),
+        stderr=stderr_file,
+        stdout=stdout_file,
+        preexec_fn=os.setpgrp,
     )
-    atexit.register(functools.partial(_cleanup_redis, redis_process))
+
+    if terminate_at_exit:
+        atexit.register(functools.partial(_cleanup_redis, redis_process))
 
     timeout = True
 

--- a/openff/bespokefit/tests/executor/test_executor.py
+++ b/openff/bespokefit/tests/executor/test_executor.py
@@ -131,11 +131,15 @@ def test_start_stop(tmpdir):
     assert executor._started is True
     assert executor._gateway_process.is_alive()
 
+    gateway_pid = executor._gateway_process.pid
+
     dir_found = os.path.isdir(os.path.join(tmpdir, "mock-exe-dir"))
 
     executor.stop()
     assert executor._started is False
-    assert not executor._gateway_process.is_alive()
+
+    with pytest.raises(OSError):
+        os.kill(gateway_pid, 0)
 
     assert dir_found
 
@@ -435,11 +439,15 @@ def test_enter_exit(tmpdir):
     with executor:
 
         assert executor._started is True
+
         assert executor._gateway_process.is_alive()
+        gateway_pid = executor._gateway_process.pid
 
         dir_found = os.path.isdir(os.path.join(tmpdir, "mock-exe-dir"))
 
     assert executor._started is False
-    assert not executor._gateway_process.is_alive()
+
+    with pytest.raises(OSError):
+        os.kill(gateway_pid, 0)
 
     assert dir_found


### PR DESCRIPTION
## Description

This PR attempts to ensure that executor processes are cleaned-up in a more sensible order, namely workers -> gateway -> redis, as both the gateway and workers attempt to connect to redis and hence if that terminates first will raise connection errors.

## Status
- [X] Ready to go