### PR TITLE
Forbid extra fields on pydantic models

### DIFF
--- a/openff/bespokefit/data/schemas/debug.json
+++ b/openff/bespokefit/data/schemas/debug.json
@@ -42,9 +42,6 @@
   "target_torsion_smirks": [
     "[!#1]~[!$(*#*)&!D1:1]-,=;!@[!$(*#*)&!D1:2]~[!#1]"
   ],
-  "target_smirks": [
-    "ProperTorsions"
-  ],
   "expand_torsion_terms": false,
   "generate_bespoke_terms": false,
   "fragmentation_engine": {

--- a/openff/bespokefit/data/schemas/default.json
+++ b/openff/bespokefit/data/schemas/default.json
@@ -1,5 +1,5 @@
 {
-  "initial_force_field": "openff-2.0.0.offxml",
+  "initial_force_field": "openff_unconstrained-2.0.0.offxml",
   "optimizer": {
     "type": "ForceBalance",
     "max_iterations": 10,
@@ -41,9 +41,6 @@
   ],
   "target_torsion_smirks": [
     "[!#1]~[!$(*#*)&!D1:1]-,=;!@[!$(*#*)&!D1:2]~[!#1]"
-  ],
-  "target_smirks": [
-    "ProperTorsions"
   ],
   "expand_torsion_terms": true,
   "generate_bespoke_terms": true,

--- a/openff/bespokefit/tests/cli/executor/test_list.py
+++ b/openff/bespokefit/tests/cli/executor/test_list.py
@@ -5,8 +5,8 @@ from openff.bespokefit.cli.executor.list import list_cli
 from openff.bespokefit.executor.services import settings
 from openff.bespokefit.executor.services.coordinator.models import (
     CoordinatorGETPageResponse,
-    CoordinatorGETResponse,
 )
+from openff.bespokefit.executor.services.models import Link
 
 
 @pytest.mark.parametrize(
@@ -20,8 +20,7 @@ def test_list_cli(n_results, expected_message, runner):
         mock_response = CoordinatorGETPageResponse(
             self="self-page",
             contents=[
-                CoordinatorGETResponse(id=f"{i}", self=f"self-{i}", stages=[])
-                for i in range(1, 1 + n_results)
+                Link(id=f"{i}", self=f"self-{i}") for i in range(1, 1 + n_results)
             ],
         )
 

--- a/openff/bespokefit/tests/cli/executor/test_run.py
+++ b/openff/bespokefit/tests/cli/executor/test_run.py
@@ -45,7 +45,7 @@ def test_run(runner, tmpdir):
                         type="fragmentation", status="success", error=None, results=None
                     )
                 ],
-            ).json(),
+            ).json(by_alias=True),
         )
 
         output = runner.invoke(

--- a/openff/bespokefit/tests/cli/executor/test_watch.py
+++ b/openff/bespokefit/tests/cli/executor/test_watch.py
@@ -30,7 +30,7 @@ def test_watch(runner):
         )
         m.get(
             mock_href,
-            text=mock_response.json(),
+            text=mock_response.json(by_alias=True),
         )
 
         output = runner.invoke(watch_cli, args=["--id", "1"])

--- a/openff/bespokefit/tests/executor/test_executor.py
+++ b/openff/bespokefit/tests/executor/test_executor.py
@@ -39,7 +39,7 @@ def mock_get_response(stage_status="running") -> CoordinatorGETResponse:
 
     with requests_mock.Mocker() as m:
 
-        m.get(mock_href, text=mock_response.json())
+        m.get(mock_href, text=mock_response.json(by_alias=True))
         yield mock_response
 
 
@@ -200,7 +200,7 @@ def test_query_coordinator(status_code: int):
 
     def mock_callback(request, context):
         context.status_code = status_code
-        return mock_response.json()
+        return mock_response.json(by_alias=True)
 
     mock_href = (
         f"http://127.0.0.1:"
@@ -244,7 +244,7 @@ def test_wait_for_stage(status):
     def mock_callback(request, context):
         context.status_code = 200
 
-        response_json = mock_response.json()
+        response_json = mock_response.json(by_alias=True)
         mock_response.stages[0].status = status
 
         nonlocal n_requests

--- a/openff/bespokefit/utilities/pydantic.py
+++ b/openff/bespokefit/utilities/pydantic.py
@@ -2,12 +2,16 @@
 """
 import numpy as np
 import pydantic
+from pydantic import Extra
 
 
 class BaseModel(pydantic.BaseModel):
     """The base model from which all data models within the package should inherit."""
 
     class Config:
+
+        extra = Extra.forbid
+
         json_encoders = {np.ndarray: lambda v: v.flatten().tolist()}
 
 


### PR DESCRIPTION
## Description

This PR updates the base model configs to forbid all extra fields. Allowing extra fields allows certain models to be parsed as the wrong type. An example of this was seen in #88 whereby factories could parse fitting schemas without error.

## Status
- [X] Ready to go