### PR TITLE
Add informative error when submitting invalid schema

### DIFF
--- a/openff/bespokefit/cli/executor/submit.py
+++ b/openff/bespokefit/cli/executor/submit.py
@@ -90,10 +90,12 @@ def _to_input_schema(
 
     except ValidationError as e:
 
+        invalid_spec_name = spec_name if spec_name is not None else spec_file_name
+
         console.print(
             Padding(
                 f"[[red]ERROR[/red]] The factory schema could not be parsed. Make sure "
-                f"{spec_name if spec_name is not None else spec_file_name} is a valid "
+                f"[repr.filename]{invalid_spec_name}[/repr.filename] is a valid "
                 f"`BespokeWorkflowFactory` schema.",
                 (1, 0, 0, 0),
             )

--- a/openff/bespokefit/cli/executor/submit.py
+++ b/openff/bespokefit/cli/executor/submit.py
@@ -5,6 +5,7 @@ import click
 import rich
 from click_option_group import optgroup
 from openff.utilities import get_data_file_path
+from pydantic import ValidationError
 from rich import pretty
 from rich.padding import Padding
 
@@ -82,8 +83,24 @@ def _to_input_schema(
             "openff.bespokefit",
         )
 
-    workflow_factory = BespokeWorkflowFactory.from_file(spec_file_name)
-    workflow_factory.initial_force_field = force_field_path
+    try:
+
+        workflow_factory = BespokeWorkflowFactory.from_file(spec_file_name)
+        workflow_factory.initial_force_field = force_field_path
+
+    except ValidationError as e:
+
+        console.print(
+            Padding(
+                f"[[red]ERROR[/red]] The factory schema could not be parsed. Make sure "
+                f"{spec_name if spec_name is not None else spec_file_name} is a valid "
+                f"`BespokeWorkflowFactory` schema.",
+                (1, 0, 0, 0),
+            )
+        )
+        console.print(Padding(str(e), (1, 1, 1, 1)))
+
+        return
 
     return workflow_factory.optimization_schema_from_molecule(molecule)
 

--- a/openff/bespokefit/tests/cli/executor/test_submit.py
+++ b/openff/bespokefit/tests/cli/executor/test_submit.py
@@ -1,3 +1,4 @@
+import json
 import os.path
 
 import numpy
@@ -57,6 +58,49 @@ def test_to_input_schema():
 
     assert isinstance(input_schema, BespokeOptimizationSchema)
     assert input_schema.id == "bespoke_task_0"
+
+
+def test_to_input_schema_file_not_found(tmpdir):
+
+    console = rich.get_console()
+
+    with console.capture() as capture:
+
+        input_schema = _to_input_schema(
+            console,
+            Molecule.from_smiles("CC"),
+            force_field_path="openff-1.2.1.offxml",
+            spec_name="fake-spec-name-123",
+            spec_file_name=None,
+        )
+
+    assert input_schema is None
+    assert (
+        "The specified schema could not be found: fake-spec-name-123" in capture.get()
+    )
+
+
+def test_to_input_schema_invalid_schema(tmpdir):
+
+    console = rich.get_console()
+
+    invalid_spec_path = os.path.join(tmpdir, "some-invalid-schema.json")
+
+    with open(invalid_spec_path, "w") as file:
+        json.dump({"invalid-filed": 1}, file)
+
+    with console.capture() as capture:
+
+        input_schema = _to_input_schema(
+            console,
+            Molecule.from_smiles("CC"),
+            force_field_path="openff-1.2.1.offxml",
+            spec_name=None,
+            spec_file_name=invalid_spec_path,
+        )
+
+    assert input_schema is None
+    assert "The factory schema could not be parsed" in capture.get()
 
 
 def test_submit_multi_molecule(tmpdir):


### PR DESCRIPTION
## Description

This PR adds a cleaner print-out to the terminal when a user tries to load an invalid workflow factory (see #88)

<img width="716" alt="Screenshot 2021-11-10 at 10 12 11" src="https://user-images.githubusercontent.com/22272126/141094215-6fc721ee-d8f7-47de-8f0f-66ca902e1258.png">

## Status
- [X] Ready to go