### PR TITLE
Make the CLI force field argument optional

### DIFF
--- a/openff/bespokefit/cli/executor/run.py
+++ b/openff/bespokefit/cli/executor/run.py
@@ -13,7 +13,7 @@ from openff.bespokefit.cli.utilities import create_command, print_header
 def _run_cli(
     input_file_path: str,
     output_file_path: str,
-    force_field_path: str,
+    force_field_path: Optional[str],
     spec_name: Optional[str],
     spec_file_name: Optional[str],
     directory: str,

--- a/openff/bespokefit/cli/executor/submit.py
+++ b/openff/bespokefit/cli/executor/submit.py
@@ -34,9 +34,11 @@ def submit_options():
             "--force-field",
             "force_field_path",
             type=click.Path(exists=False, file_okay=True, dir_okay=False),
-            help="The initial force field to build upon",
-            default="openff-2.0.0.offxml",
+            help="The initial force field to build upon. This will overwrite the value "
+            "in the workflow spec if provided.",
+            default=None,
             show_default=True,
+            required=False,
         ),
         optgroup.group("Optimization configuration"),
         optgroup.option(
@@ -59,7 +61,7 @@ def submit_options():
 def _to_input_schema(
     console: "rich.Console",
     molecule: "Molecule",
-    force_field_path: str,
+    force_field_path: Optional[str],
     spec_name: Optional[str],
     spec_file_name: Optional[str],
 ) -> Optional["BespokeOptimizationSchema"]:
@@ -88,7 +90,9 @@ def _to_input_schema(
             )
 
         workflow_factory = BespokeWorkflowFactory.from_file(spec_file_name)
-        workflow_factory.initial_force_field = force_field_path
+
+        if force_field_path is not None:
+            workflow_factory.initial_force_field = force_field_path
 
     except (FileNotFoundError, RuntimeError) as e:
 
@@ -126,7 +130,7 @@ def _to_input_schema(
 def _submit(
     console: "rich.Console",
     input_file_path: str,
-    force_field_path: str,
+    force_field_path: Optional[str],
     spec_name: Optional[str],
     spec_file_name: Optional[str],
 ) -> Optional["CoordinatorPOSTResponse"]:
@@ -176,7 +180,7 @@ def _submit(
 
 def _submit_cli(
     input_file_path: str,
-    force_field_path: str,
+    force_field_path: Optional[str],
     spec_name: Optional[str],
     spec_file_name: Optional[str],
 ):

--- a/openff/bespokefit/tests/cli/executor/test_submit.py
+++ b/openff/bespokefit/tests/cli/executor/test_submit.py
@@ -46,18 +46,23 @@ def test_to_input_schema_mutual_exclusive_args(
     assert (input_schema is None) == output_is_none
 
 
-def test_to_input_schema():
+@pytest.mark.parametrize("force_field_path", [None, "openff-1.0.0.offxml"])
+def test_to_input_schema(force_field_path):
 
     input_schema = _to_input_schema(
         rich.get_console(),
         Molecule.from_smiles("CC"),
-        force_field_path="openff-1.2.1.offxml",
+        force_field_path=force_field_path,
         spec_name="debug",
         spec_file_name=None,
     )
 
     assert isinstance(input_schema, BespokeOptimizationSchema)
     assert input_schema.id == "bespoke_task_0"
+
+    assert (
+        "2021-08-16" if force_field_path is None else "2019-10-10"
+    ) in input_schema.initial_force_field
 
 
 def test_to_input_schema_file_not_found(tmpdir):


### PR DESCRIPTION
## Description

This PR makes the force field argument passed to the executor CLI, such that it will only overwrite the schema value if provided.

## Status
- [X] Ready to go