### PR TITLE
Fix get_atom_symmetries with OpenEye installed without license

### DIFF
--- a/openff/bespokefit/utilities/molecule.py
+++ b/openff/bespokefit/utilities/molecule.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
 
 from openff.toolkit.topology import Molecule
+from openff.toolkit.utils.exceptions import ToolkitUnavailableException
 
 
 def _oe_get_atom_symmetries(molecule: Molecule) -> List[int]:
@@ -29,7 +30,7 @@ def get_atom_symmetries(molecule: Molecule) -> List[int]:
 
     try:
         return _oe_get_atom_symmetries(molecule)
-    except (ImportError, ModuleNotFoundError):
+    except (ImportError, ModuleNotFoundError, ToolkitUnavailableException):
         return _rd_get_atom_symmetries(molecule)
 
 


### PR DESCRIPTION
## Description
When OpenEye is installed, but the license is unavailable, `openff.bespokefit.utilities.molecule.get_atom_symmetries` fails with an extremely confusing error: "This function requires the OpenEye Toolkit". This is because `_oe_get_atom_symmetries` calls the OpenFF Toolkit's `Molecule.to_openeye()`, which raises an error that is not caught by bespokefit. This PR fixes this.

## Status
- [x] Ready to go