### PR TITLE
Support seeding torsiondrives with multiple confs

### DIFF
--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -36,6 +36,7 @@ dependencies:
     ### Bespoke dependencies
 
   - qcportal >=0.15.6
+  - qcelemental >=0.24.0
   - qcengine >=0.20.0
   - chemper
   - geometric

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   - qcportal >=0.15.6
   - qcelemental >=0.24.0
-  - qcengine >=0.20.0
+  - qcengine >=0.21.0
   - chemper
   - geometric
   - torsiondrive

--- a/openff/bespokefit/executor/services/qcgenerator/app.py
+++ b/openff/bespokefit/executor/services/qcgenerator/app.py
@@ -112,7 +112,7 @@ def get_qc_result_molecule_image(qc_calc_id: str):
         )
 
         svg_content = smiles_to_image(
-            qc_result.initial_molecule.extras[
+            qc_result.initial_molecule[0].extras[
                 "canonical_isomeric_explicit_hydrogen_mapped_smiles"
             ],
             highlight_atoms=highlight_atoms,

--- a/openff/bespokefit/executor/services/qcgenerator/worker.py
+++ b/openff/bespokefit/executor/services/qcgenerator/worker.py
@@ -46,8 +46,7 @@ def compute_torsion_drive(task_json: str) -> TorsionDriveResult:
     task = Torsion1DTask.parse_raw(task_json)
 
     molecule: Molecule = Molecule.from_smiles(task.smiles)
-    # TODO: Ask Josh about multiple conformers.
-    molecule.generate_conformers(n_conformers=1)
+    molecule.generate_conformers(n_conformers=task.n_conformers)
 
     map_to_atom_index = {
         map_index: atom_index
@@ -88,7 +87,9 @@ def compute_torsion_drive(task_json: str) -> TorsionDriveResult:
                 isomeric=True, explicit_hydrogens=True, mapped=True
             )
         },
-        initial_molecule=molecule.to_qcschema(),
+        initial_molecule=[
+            molecule.to_qcschema(conformer=i) for i in range(molecule.n_conformers)
+        ],
         input_specification=QCInputSpecification(
             model=task.model,
             driver=DriverEnum.gradient,

--- a/openff/bespokefit/optimizers/forcebalance/factories.py
+++ b/openff/bespokefit/optimizers/forcebalance/factories.py
@@ -169,7 +169,7 @@ class _TargetFactory(Generic[T], abc.ABC):
 
             elif isinstance(qc_result, TorsionDriveResult):
 
-                cmiles = qc_result.initial_molecule.extras[
+                cmiles = qc_result.initial_molecule[0].extras[
                     "canonical_isomeric_explicit_hydrogen_mapped_smiles"
                 ]
 

--- a/openff/bespokefit/schema/data.py
+++ b/openff/bespokefit/schema/data.py
@@ -75,7 +75,7 @@ class LocalQCData(GenericModel, Generic[QCDataType]):
                 model=Model(method=record.qc_spec.method, basis=record.qc_spec.basis),
                 extras=record.extras,
             ),
-            initial_molecule=molecule.to_qcschema(),
+            initial_molecule=[molecule.to_qcschema()],
             optimization_spec=OptimizationSpecification(
                 procedure=record.optimization_spec.program,
                 keywords=record.optimization_spec.keywords,

--- a/openff/bespokefit/schema/data.py
+++ b/openff/bespokefit/schema/data.py
@@ -68,7 +68,7 @@ class LocalQCData(GenericModel, Generic[QCDataType]):
         assert record.status == RecordStatusEnum.complete
 
         return TorsionDriveResult(
-            keywords=record.keywords,
+            keywords=record.keywords.dict(),
             extras=record.extras,
             input_specification=QCInputSpecification(
                 driver=record.qc_spec.driver,

--- a/openff/bespokefit/schema/tasks.py
+++ b/openff/bespokefit/schema/tasks.py
@@ -70,6 +70,11 @@ class Torsion1DTaskSpec(QCGenerationTask):
         "in the scan.",
     )
 
+    n_conformers: conint(gt=0) = Field(
+        10,
+        description="The number of initial conformers to seed the torsion drive with.",
+    )
+
 
 class Torsion1DTask(Torsion1DTaskSpec):
 

--- a/openff/bespokefit/tests/conftest.py
+++ b/openff/bespokefit/tests/conftest.py
@@ -144,7 +144,7 @@ def qc_torsion_drive_qce_result(
             driver=qc_record.qc_spec.driver,
             model=Model(method=qc_record.qc_spec.method, basis=qc_record.qc_spec.basis),
         ),
-        initial_molecule=molecule.to_qcschema(),
+        initial_molecule=[molecule.to_qcschema()],
         optimization_spec=OptimizationSpecification(
             procedure=qc_record.optimization_spec.program,
             keywords=qc_record.optimization_spec.keywords,

--- a/openff/bespokefit/tests/conftest.py
+++ b/openff/bespokefit/tests/conftest.py
@@ -133,7 +133,7 @@ def qc_torsion_drive_qce_result(
     qc_record, molecule = qc_torsion_drive_record
 
     qc_result = QCTorsionDriveResult(
-        keywords=qc_record.keywords,
+        keywords=qc_record.keywords.dict(),
         extras={
             "id": qc_record.id,
             "canonical_isomeric_explicit_hydrogen_mapped_smiles": molecule.to_smiles(

--- a/openff/bespokefit/tests/executor/services/qcgenerator/test_app.py
+++ b/openff/bespokefit/tests/executor/services/qcgenerator/test_app.py
@@ -53,7 +53,7 @@ def mock_torsion_drive_result() -> TorsionDriveResult:
         input_specification=QCInputSpecification(
             model=Model(method="uff", basis=None), driver=DriverEnum.gradient
         ),
-        initial_molecule=molecule.to_qcschema(),
+        initial_molecule=[molecule.to_qcschema()],
         optimization_spec=OptimizationSpecification(procedure="geometric"),
         final_energies={"[180]": 1.0},
         final_molecules={"[180]": molecule.to_qcschema()},


### PR DESCRIPTION
## Description

This PR adds support for seeding torsion drives with multiple conformers as specified by the task spec now support is added upstream (https://github.com/MolSSI/QCElemental/pull/281, https://github.com/MolSSI/QCEngine/pull/325).

This PR should also fix the CI failures on main.

## Todos

  - [x] Wait for a new QCEngine release that contains https://github.com/MolSSI/QCEngine/pull/325

## Status
- [x] Ready to go