### PR TITLE
cache update via cli

### DIFF
--- a/openff/bespokefit/cli/cache.py
+++ b/openff/bespokefit/cli/cache.py
@@ -1,0 +1,47 @@
+import click
+import redis
+import rich
+from click_option_group import optgroup
+from rich import pretty
+from typing import Optional
+from typing import Union
+
+from openff.bespokefit.cli.utilities import create_command, print_header
+from openff.bespokefit.executor.utilities.redis import is_redis_available, launch_redis
+from openff.qcsubmit.results import TorsionDriveResultCollection, OptimizationResultCollection
+
+@click.group("cache")
+def cache_cli():
+    #TODO do we want the redius database to be saved in a standard location as it is directory dependent?
+    """Commands to manually update the qc data cache."""
+
+
+
+def update_from_qcsubmit_options(
+        result_file: str,
+        launch_redis_if_unavailable: Optional[bool] = True,
+):
+    return [
+        optgroup("Input Configuration"),
+        optgroup.option()
+    ]
+
+
+def update():
+    """
+    The main worker function which updates the redis cache with qcsubmit results objects.
+    """
+    # first download qcsubmit results
+    # connect to / launch redis
+    # save and close
+    # have options for files and address as they all go through the same in fastructure should they be mutally exclusive?
+
+    pass
+
+
+def _update_from_qcsubmit_result(qcsubmit_results: Union[TorsionDriveResultCollection, OptimizationResultCollection], redis_connection: redis.Redis):
+    """Update the qcgeneration redis cache using qcsubmit results objects."""
+    # take the results and convert them to tasks and store in redis if not present
+    pass
+
+

--- a/openff/bespokefit/cli/cli.py
+++ b/openff/bespokefit/cli/cli.py
@@ -1,5 +1,6 @@
 import click
 
+from openff.bespokefit.cli.cache import cache_cli
 from openff.bespokefit.cli.executor import executor_cli
 from openff.bespokefit.cli.prepare import prepare_cli
 
@@ -11,3 +12,4 @@ def cli():
 
 cli.add_command(executor_cli)
 cli.add_command(prepare_cli)
+cli.add_command(cache_cli)

--- a/openff/bespokefit/schema/data.py
+++ b/openff/bespokefit/schema/data.py
@@ -66,10 +66,13 @@ class LocalQCData(GenericModel, Generic[QCDataType]):
     ) -> TorsionDriveResult:
 
         assert record.status == RecordStatusEnum.complete
+        # add the program to the model which we need for the cache
+        extras = record.extras
+        extras["program"] = record.qc_spec.program
 
         return TorsionDriveResult(
             keywords=record.keywords.dict(),
-            extras=record.extras,
+            extras=extras,
             input_specification=QCInputSpecification(
                 driver=record.qc_spec.driver,
                 model=Model(method=record.qc_spec.method, basis=record.qc_spec.basis),

--- a/openff/bespokefit/schema/tasks.py
+++ b/openff/bespokefit/schema/tasks.py
@@ -1,9 +1,12 @@
 import abc
-from typing import Optional, Tuple
+from typing import Optional, Tuple, overload
 
+from openff.toolkit.topology import Molecule
 from openff.qcsubmit.procedures import GeometricProcedure
 from pydantic import Field, conint
 from qcelemental.models.common_models import Model
+from qcelemental.models import AtomicResult
+from qcelemental.models.procedures import OptimizationResult, TorsionDriveResult
 from typing_extensions import Literal
 
 from openff.bespokefit.utilities.pydantic import BaseModel
@@ -86,3 +89,39 @@ class Torsion1DTask(Torsion1DTaskSpec):
         None,
         description="The **map** indices of the atoms in the bond to scan around.",
     )
+
+
+@overload
+def task_from_result(result: AtomicResult) -> HessianTask:
+    ...
+
+
+@overload
+def task_from_result(result: OptimizationResult) -> OptimizationTask:
+    ...
+
+
+@overload
+def task_from_result(result: TorsionDriveResult) -> Torsion1DTask:
+    ...
+
+
+def task_from_result(result):
+    """
+    Convert a result into a task to populate the cache for the result.
+    """
+
+    if isinstance(result, TorsionDriveResult):
+        dihedral = result.keywords.dihedrals[0]
+        off_mol = Molecule.from_qcschema(result.initial_molecule[0])
+        return Torsion1DTask(
+            smiles=off_mol.to_smiles(isomeric=True, explicit_hydrogens=True, mapped=True),
+            program=result.extras["program"],
+            model=result.input_specification.model,
+            central_bond=(dihedral[1] + 1, dihedral[2] + 1),
+            grid_spacing=result.keywords.grid_spacing[0],
+            scan_range=result.keywords.dihedral_ranges,
+            optimization_spec=GeometricProcedure.from_opt_spec(result.optimization_spec)
+        )
+    else:
+        raise NotImplementedError()

--- a/openff/bespokefit/schema/tasks.py
+++ b/openff/bespokefit/schema/tasks.py
@@ -1,11 +1,11 @@
 import abc
 from typing import Optional, Tuple, overload
 
-from openff.toolkit.topology import Molecule
 from openff.qcsubmit.procedures import GeometricProcedure
+from openff.toolkit.topology import Molecule
 from pydantic import Field, conint
-from qcelemental.models.common_models import Model
 from qcelemental.models import AtomicResult
+from qcelemental.models.common_models import Model
 from qcelemental.models.procedures import OptimizationResult, TorsionDriveResult
 from typing_extensions import Literal
 
@@ -115,13 +115,17 @@ def task_from_result(result):
         dihedral = result.keywords.dihedrals[0]
         off_mol = Molecule.from_qcschema(result.initial_molecule[0])
         return Torsion1DTask(
-            smiles=off_mol.to_smiles(isomeric=True, explicit_hydrogens=True, mapped=True),
+            smiles=off_mol.to_smiles(
+                isomeric=True, explicit_hydrogens=True, mapped=True
+            ),
             program=result.extras["program"],
             model=result.input_specification.model,
             central_bond=(dihedral[1] + 1, dihedral[2] + 1),
             grid_spacing=result.keywords.grid_spacing[0],
             scan_range=result.keywords.dihedral_ranges,
-            optimization_spec=GeometricProcedure.from_opt_spec(result.optimization_spec)
+            optimization_spec=GeometricProcedure.from_opt_spec(
+                result.optimization_spec
+            ),
         )
     else:
         raise NotImplementedError()

--- a/openff/bespokefit/workflows/bespoke.py
+++ b/openff/bespokefit/workflows/bespoke.py
@@ -19,8 +19,8 @@ from openff.qcsubmit.workflow_components import ComponentResult
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
 from pydantic import Field, validator
-from qcportal.models import OptimizationRecord, ResultRecord, TorsionDriveRecord
 from qcelemental.models.common_models import Model
+from qcportal.models import OptimizationRecord, ResultRecord, TorsionDriveRecord
 
 from openff.bespokefit.exceptions import (
     MissingTorsionTargetSMARTS,

--- a/openff/bespokefit/workflows/bespoke.py
+++ b/openff/bespokefit/workflows/bespoke.py
@@ -28,6 +28,7 @@ from openff.toolkit.typing.engines.smirnoff import (
 )
 from pydantic import Field, validator
 from qcportal.models import OptimizationRecord, ResultRecord, TorsionDriveRecord
+from qcelemental.models.common_models import Model
 
 from openff.bespokefit.exceptions import (
     FragmenterError,
@@ -566,7 +567,14 @@ class BespokeWorkflowFactory(ClassBase):
 
             target_schema.reference_data = BespokeQCData(
                 spec=task_type_to_spec[task_type](
-                    program=default_qc_spec.program, model=default_qc_spec.qc_model
+                    program=default_qc_spec.program.lower(),
+                    # lower to hit the cache more often
+                    model=Model(
+                        method=default_qc_spec.method.lower(),
+                        basis=default_qc_spec.basis.lower()
+                        if default_qc_spec.basis is not None
+                        else default_qc_spec.basis,
+                    ),
                 )
             )
 


### PR DESCRIPTION
## Description
This PR adds the ability to update the QC calculation cache using results computed in qcarchive, these are converted to local results and mock celery results are added to a local redis instance.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] support qcsubmit results files
  - [ ] support qcarchive directly 
  - [ ] add tests

## Questions
- [ ] Question1

## Status
- [ ] Ready to go