### PR TITLE
Race condition fix

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Run tests
         run: |
+          pip install -e .
           python -m pytest --durations=0 openff/bespokefit/_tests
 
       - name: Run Integration Tests

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -71,10 +71,15 @@ jobs:
       - name: Run Integration Tests
         if: ${{ matrix.integration == true }}
         run: |
+          mkdir integration_test_directory
           openff-bespoke executor run --smiles                 'CC'               \
                                       --workflow               'default'          \
                                       --default-qc-spec        xtb gfn2xtb none   \
-                                      --target-torsion         '[C:1]-[C:2]'
+                                      --target-torsion         '[C:1]-[C:2]'      \
+                                      --directory              integration_test_directory
+
+          ls -lhrt integration_test_directory/
+          cat integration_test_directory/*.log
 
       - name: Go back to pull request HEAD
         # setup-micromamba needs the environment file to exist, which it might not on the most recent tag

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -65,7 +65,6 @@ jobs:
 
       - name: Run tests
         run: |
-          pip install -e .
           python -m pytest --durations=0 openff/bespokefit/_tests
 
       - name: Run Integration Tests

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -71,15 +71,10 @@ jobs:
       - name: Run Integration Tests
         if: ${{ matrix.integration == true }}
         run: |
-          mkdir integration_test_directory
           openff-bespoke executor run --smiles                 'CC'               \
                                       --workflow               'default'          \
                                       --default-qc-spec        xtb gfn2xtb none   \
                                       --target-torsion         '[C:1]-[C:2]'      \
-                                      --directory              integration_test_directory
-
-          ls -lhrt integration_test_directory/
-          cat integration_test_directory/*.log
 
       - name: Go back to pull request HEAD
         # setup-micromamba needs the environment file to exist, which it might not on the most recent tag

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -52,16 +52,16 @@ jobs:
         env:
           SECRET_OE_LICENSE: ${{ secrets.OE_LICENSE }}
 
-      - name: Checkout most recent tag
-        id: vars
-        run: |
-          echo "PULL_REQUEST_HEAD=$(git log -1 --format=%H)" >> $GITHUB_OUTPUT
+      #- name: Checkout most recent tag
+      #  id: vars
+      #  run: |
+      #    echo "PULL_REQUEST_HEAD=$(git log -1 --format=%H)" >> $GITHUB_OUTPUT
 
-          git fetch --all
-          # ask pretty please for it to actually fetch recent tags
-          # https://github.com/openforcefield/openff-bespokefit/issues/403
-          git fetch --prune --unshallow --tags
-          git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
+      #    git fetch --all
+      #    # ask pretty please for it to actually fetch recent tags
+      #    # https://github.com/openforcefield/openff-bespokefit/issues/403
+      #    git fetch --prune --unshallow --tags
+      #    git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
 
       - name: Run tests
         run: |

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -52,16 +52,16 @@ jobs:
         env:
           SECRET_OE_LICENSE: ${{ secrets.OE_LICENSE }}
 
-      #- name: Checkout most recent tag
-      #  id: vars
-      #  run: |
-      #    echo "PULL_REQUEST_HEAD=$(git log -1 --format=%H)" >> $GITHUB_OUTPUT
+      - name: Checkout most recent tag
+        id: vars
+        run: |
+          echo "PULL_REQUEST_HEAD=$(git log -1 --format=%H)" >> $GITHUB_OUTPUT
 
-      #    git fetch --all
-      #    # ask pretty please for it to actually fetch recent tags
-      #    # https://github.com/openforcefield/openff-bespokefit/issues/403
-      #    git fetch --prune --unshallow --tags
-      #    git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
+          git fetch --all
+          # ask pretty please for it to actually fetch recent tags
+          # https://github.com/openforcefield/openff-bespokefit/issues/403
+          git fetch --prune --unshallow --tags
+          git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
 
       - name: Run tests
         run: |
@@ -74,7 +74,7 @@ jobs:
           openff-bespoke executor run --smiles                 'CC'               \
                                       --workflow               'default'          \
                                       --default-qc-spec        xtb gfn2xtb none   \
-                                      --target-torsion         '[C:1]-[C:2]'      \
+                                      --target-torsion         '[C:1]-[C:2]'
 
       - name: Go back to pull request HEAD
         # setup-micromamba needs the environment file to exist, which it might not on the most recent tag

--- a/openff/bespokefit/_tests/executor/services/coordinator/test_storage.py
+++ b/openff/bespokefit/_tests/executor/services/coordinator/test_storage.py
@@ -136,7 +136,9 @@ def test_snapshot_task_status_multiple(redis_connection, bespoke_optimization_sc
     assert running_snapshot == [1, 2]
 
 
-def test_snapshot_task_status_independence(redis_connection, bespoke_optimization_schema):
+def test_snapshot_task_status_independence(
+    redis_connection, bespoke_optimization_schema
+):
     """Test that snapshot is independent of queue changes."""
     # Create 2 tasks
     for _ in range(2):
@@ -196,7 +198,9 @@ def test_remove_task_status_absent(redis_connection, bespoke_optimization_schema
     assert get_n_tasks(TaskStatus.waiting) == 1
 
 
-def test_remove_task_status_nonexistent_id(redis_connection, bespoke_optimization_schema):
+def test_remove_task_status_nonexistent_id(
+    redis_connection, bespoke_optimization_schema
+):
     """Test remove_task_status with task ID that doesn't exist anywhere."""
     # Create one task
     create_task(bespoke_optimization_schema)
@@ -253,8 +257,12 @@ def test_remove_task_status_middle(redis_connection, bespoke_optimization_schema
     assert snapshot == [1, 3]
 
 
-@pytest.mark.parametrize("status", [TaskStatus.waiting, TaskStatus.running, TaskStatus.complete])
-def test_remove_task_status_all_statuses(redis_connection, bespoke_optimization_schema, status):
+@pytest.mark.parametrize(
+    "status", [TaskStatus.waiting, TaskStatus.running, TaskStatus.complete]
+)
+def test_remove_task_status_all_statuses(
+    redis_connection, bespoke_optimization_schema, status
+):
     """Test remove_task_status works with all task statuses."""
     # Create task and move to target status
     task_id = create_task(bespoke_optimization_schema)

--- a/openff/bespokefit/_tests/executor/services/coordinator/test_storage.py
+++ b/openff/bespokefit/_tests/executor/services/coordinator/test_storage.py
@@ -11,7 +11,9 @@ from openff.bespokefit.executor.services.coordinator.storage import (
     peek_task_status,
     pop_task_status,
     push_task_status,
+    remove_task_status,
     save_task,
+    snapshot_task_status,
 )
 
 
@@ -92,3 +94,178 @@ def test_save_task(bespoke_optimization_schema):
 
     updated_task = get_task(task.id)
     assert updated_task.pending_stages == []
+
+
+def test_snapshot_task_status_empty(redis_connection):
+    """Test snapshot_task_status returns empty list when no tasks in queue."""
+    snapshot = snapshot_task_status(TaskStatus.waiting)
+    assert snapshot == []
+
+    snapshot = snapshot_task_status(TaskStatus.running)
+    assert snapshot == []
+
+
+def test_snapshot_task_status_single(redis_connection, bespoke_optimization_schema):
+    """Test snapshot_task_status returns single task correctly."""
+    task_id = create_task(bespoke_optimization_schema)
+
+    snapshot = snapshot_task_status(TaskStatus.waiting)
+    assert snapshot == [1]
+    assert isinstance(snapshot[0], int)
+
+
+def test_snapshot_task_status_multiple(redis_connection, bespoke_optimization_schema):
+    """Test snapshot_task_status returns multiple tasks in correct order."""
+    # Create 3 tasks
+    for _ in range(3):
+        create_task(bespoke_optimization_schema)
+
+    # All should be in waiting queue
+    snapshot = snapshot_task_status(TaskStatus.waiting)
+    assert snapshot == [1, 2, 3]
+
+    # Move some to running
+    push_task_status(pop_task_status(TaskStatus.waiting), TaskStatus.running)
+    push_task_status(pop_task_status(TaskStatus.waiting), TaskStatus.running)
+
+    # Check both queues
+    waiting_snapshot = snapshot_task_status(TaskStatus.waiting)
+    running_snapshot = snapshot_task_status(TaskStatus.running)
+
+    assert waiting_snapshot == [3]
+    assert running_snapshot == [1, 2]
+
+
+def test_snapshot_task_status_independence(redis_connection, bespoke_optimization_schema):
+    """Test that snapshot is independent of queue changes."""
+    # Create 2 tasks
+    for _ in range(2):
+        create_task(bespoke_optimization_schema)
+
+    # Take snapshot
+    snapshot = snapshot_task_status(TaskStatus.waiting)
+    assert snapshot == [1, 2]
+
+    # Modify queue after snapshot
+    pop_task_status(TaskStatus.waiting)
+
+    # Snapshot should be unchanged
+    assert snapshot == [1, 2]
+
+    # But new snapshot should reflect changes
+    new_snapshot = snapshot_task_status(TaskStatus.waiting)
+    assert new_snapshot == [2]
+
+
+def test_remove_task_status_present(redis_connection, bespoke_optimization_schema):
+    """Test remove_task_status successfully removes a present task."""
+    # Create and queue 3 tasks
+    for _ in range(3):
+        task_id = create_task(bespoke_optimization_schema)
+        push_task_status(pop_task_status(TaskStatus.waiting), TaskStatus.running)
+
+    # Verify all in running queue
+    assert get_n_tasks(TaskStatus.running) == 3
+    snapshot = snapshot_task_status(TaskStatus.running)
+    assert snapshot == [1, 2, 3]
+
+    # Remove task 2
+    removed_count = remove_task_status(2, TaskStatus.running)
+
+    # Should return 1 (one task removed)
+    assert removed_count == 1
+
+    # Task should be gone from queue
+    snapshot = snapshot_task_status(TaskStatus.running)
+    assert snapshot == [1, 3]
+    assert get_n_tasks(TaskStatus.running) == 2
+
+
+def test_remove_task_status_absent(redis_connection, bespoke_optimization_schema):
+    """Test remove_task_status returns 0 when task not in queue."""
+    # Create task but leave in waiting queue
+    create_task(bespoke_optimization_schema)
+
+    # Try to remove from running queue (where it doesn't exist)
+    removed_count = remove_task_status(1, TaskStatus.running)
+
+    # Should return 0 (no tasks removed)
+    assert removed_count == 0
+
+    # Task should still be in waiting queue
+    assert get_n_tasks(TaskStatus.waiting) == 1
+
+
+def test_remove_task_status_nonexistent_id(redis_connection, bespoke_optimization_schema):
+    """Test remove_task_status with task ID that doesn't exist anywhere."""
+    # Create one task
+    create_task(bespoke_optimization_schema)
+
+    # Try to remove task 999 which doesn't exist
+    removed_count = remove_task_status(999, TaskStatus.waiting)
+
+    # Should return 0
+    assert removed_count == 0
+
+    # Original task should be unaffected
+    assert get_n_tasks(TaskStatus.waiting) == 1
+
+
+def test_remove_task_status_head(redis_connection, bespoke_optimization_schema):
+    """Test remove_task_status can remove head of queue."""
+    # Create 3 tasks
+    for _ in range(3):
+        create_task(bespoke_optimization_schema)
+
+    # Remove first task (head)
+    removed_count = remove_task_status(1, TaskStatus.waiting)
+
+    assert removed_count == 1
+    snapshot = snapshot_task_status(TaskStatus.waiting)
+    assert snapshot == [2, 3]
+
+
+def test_remove_task_status_tail(redis_connection, bespoke_optimization_schema):
+    """Test remove_task_status can remove tail of queue."""
+    # Create 3 tasks
+    for _ in range(3):
+        create_task(bespoke_optimization_schema)
+
+    # Remove last task (tail)
+    removed_count = remove_task_status(3, TaskStatus.waiting)
+
+    assert removed_count == 1
+    snapshot = snapshot_task_status(TaskStatus.waiting)
+    assert snapshot == [1, 2]
+
+
+def test_remove_task_status_middle(redis_connection, bespoke_optimization_schema):
+    """Test remove_task_status can remove middle element."""
+    # Create 3 tasks
+    for _ in range(3):
+        create_task(bespoke_optimization_schema)
+
+    # Remove middle task
+    removed_count = remove_task_status(2, TaskStatus.waiting)
+
+    assert removed_count == 1
+    snapshot = snapshot_task_status(TaskStatus.waiting)
+    assert snapshot == [1, 3]
+
+
+@pytest.mark.parametrize("status", [TaskStatus.waiting, TaskStatus.running, TaskStatus.complete])
+def test_remove_task_status_all_statuses(redis_connection, bespoke_optimization_schema, status):
+    """Test remove_task_status works with all task statuses."""
+    # Create task and move to target status
+    task_id = create_task(bespoke_optimization_schema)
+
+    if status == TaskStatus.running:
+        push_task_status(pop_task_status(TaskStatus.waiting), TaskStatus.running)
+    elif status == TaskStatus.complete:
+        push_task_status(pop_task_status(TaskStatus.waiting), TaskStatus.complete)
+
+    # Remove from target status
+    removed_count = remove_task_status(task_id, status)
+
+    assert removed_count == 1
+    assert get_n_tasks(status) == 0

--- a/openff/bespokefit/executor/services/coordinator/storage.py
+++ b/openff/bespokefit/executor/services/coordinator/storage.py
@@ -130,3 +130,15 @@ def push_task_status(task_id: int, status: TaskStatus):
 def save_task(task: CoordinatorTask):
     connection = connect_to_default_redis()
     connection.set(_task_id_to_key(int(task.id)), pickle.dumps(task.dict()))
+
+
+def snapshot_task_status(status: TaskStatus) -> List[int]:
+    connection = connect_to_default_redis()
+    task_ids = connection.lrange(_QUEUE_NAMES[status], 0, -1)
+    return [int(task_id) for task_id in task_ids]
+
+
+def remove_task_status(task_id: int, status: TaskStatus) -> int:
+    connection = connect_to_default_redis()
+    count = connection.lrem(_QUEUE_NAMES[status], 0, str(task_id))
+    return count

--- a/openff/bespokefit/executor/services/coordinator/storage.py
+++ b/openff/bespokefit/executor/services/coordinator/storage.py
@@ -109,8 +109,8 @@ def get_n_tasks(status: Optional[TaskStatus] = None) -> int:
 def peek_task_status(status: TaskStatus) -> Optional[int]:
     connection = connect_to_default_redis()
 
-    task_id = connection.lrange(_QUEUE_NAMES[status], 0, 0)
-    return None if len(task_id) == 0 else int(task_id[0])
+    task_id = connection.lindex(_QUEUE_NAMES[status], 0)
+    return None if task_id is None else int(task_id)
 
 
 def pop_task_status(status: TaskStatus) -> Optional[int]:

--- a/openff/bespokefit/executor/services/coordinator/worker.py
+++ b/openff/bespokefit/executor/services/coordinator/worker.py
@@ -79,9 +79,6 @@ async def cycle():  # pragma: no cover
                     break
 
                 has_finished = await _process_task(task_id)
-                # Needed to let other async threads run even if there are hundreds of
-                # tasks running
-                await asyncio.sleep(0.0)
 
                 # sometimes we can lose the task id if it was removed externally and get a NoneType which breaks the update
                 pop_task_id = pop_task_status(TaskStatus.running)
@@ -102,6 +99,9 @@ async def cycle():  # pragma: no cover
                 processed_task_ids.add(task_id)
 
                 task_id = peek_task_status(TaskStatus.running)
+                # Needed to let other async threads run even if there are hundreds of
+                # tasks running
+                await asyncio.sleep(0.0)
 
             n_running_tasks = get_n_tasks(TaskStatus.running)
             n_tasks_to_queue = min(


### PR DESCRIPTION
## Description
I think there is a race condition in the coordinator worker [cycle](https://github.com/openforcefield/openff-bespokefit/blob/ef15e0dd523ff441f463833f29276217fd0fb337/openff/bespokefit/executor/services/coordinator/worker.py#L58) method. This results in the task id we get from looking at the head of the task queue [here](https://github.com/openforcefield/openff-bespokefit/blob/ef15e0dd523ff441f463833f29276217fd0fb337/openff/bespokefit/executor/services/coordinator/worker.py#L72) not matching the id we process after updating the [task](https://github.com/openforcefield/openff-bespokefit/blob/ef15e0dd523ff441f463833f29276217fd0fb337/openff/bespokefit/executor/services/coordinator/worker.py#L85) if there are few tasks in the queue this results in a `NoneTypeError` that we sometimes see in the CI or in production mode with a low number of jobs. 

This update uses a snapshot of the task queue to process the results rather than relying on the queues not changing between the peek, updating the task and then removing the id. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go