### PR TITLE
Downpin QCElemental and QCEngine

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.12", "3.13"]
         pydantic-version: ["1"]
         openeye: [true, false]
         integration: [true]

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.11", "3.12"]
         pydantic-version: ["1"]
         openeye: [true, false]
         integration: [true]

--- a/devtools/conda-envs/docs-env.yaml
+++ b/devtools/conda-envs/docs-env.yaml
@@ -33,8 +33,8 @@ dependencies:
     ### Bespoke dependencies
 
   - qcportal ==0.53
-  - qcelemental
-  - qcengine
+  - qcelemental <0.50
+  - qcengine <0.50
   - chemper
   - geometric <1
   - torsiondrive

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -23,8 +23,7 @@ dependencies:
   - rdkit =2024.03.5
   - ambertools >=22
   - openff-utilities
-  - openff-toolkit =0.16.5
-  - openff-interchange =0.3.29
+  - openff-toolkit >=0.15
   - openff-forcefields >=2024.04.0
   - openff-qcsubmit >=0.55
   - openmm >=7.6.0

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -23,7 +23,8 @@ dependencies:
   - rdkit =2024.03.5
   - ambertools >=22
   - openff-utilities
-  - openff-toolkit >=0.15
+  - openff-toolkit =0.16.5
+  - openff-interchange =0.3.29
   - openff-forcefields >=2024.04.0
   - openff-qcsubmit >=0.55
   - openmm >=7.6.0

--- a/devtools/conda-envs/no_openeye.yaml
+++ b/devtools/conda-envs/no_openeye.yaml
@@ -36,8 +36,8 @@ dependencies:
     ### Bespoke dependencies
 
   - qcportal >=0.53
-  - qcelemental
-  - qcengine
+  - qcelemental <0.50
+  - qcengine <0.50
   - chemper
   - geometric =1
   - torsiondrive

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -1,21 +1,20 @@
 name: bespokefit-test
 
 channels:
-  - openeye
   - conda-forge
 
 dependencies:
 
     # Base depends
-  - python
+  - python =3.13
   - pip
   # https://github.com/leeping/forcebalance/issues/307
   - setuptools<82
 
     ### Core dependencies.
 
-  - numpy
-  - pydantic
+  - numpy ==1
+  - pydantic =1
   - pyyaml
   - tqdm
   - rich
@@ -23,18 +22,18 @@ dependencies:
   - click-option-group
   - rdkit =2024.03.5
   - openff-utilities
-  - openff-toolkit >=0.16.5
-  - openff-interchange =0.3.29
+  - openff-toolkit ==0.16.5
+  - openff-interchange ==0.3.29
   - openff-forcefields >=2024.04.0
   - openff-units
   - openff-qcsubmit >=0.55
   - openmm >=7.6.0
 
     # Optional
-  - forcebalance >=1.9.6
+  - forcebalance ==1.9.6
   - openff-fragmenter-base
   - xtb-python
-  - openeye-toolkits
+  - openeye::openeye-toolkits
 
     ### Bespoke dependencies
 

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -13,8 +13,8 @@ dependencies:
 
     ### Core dependencies.
 
-  - numpy ==1
-  - pydantic =1
+  - numpy
+  - pydantic
   - pyyaml
   - tqdm
   - rich

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 
     # Base depends
-  - python =3.13
+  - python
   - pip
   # https://github.com/leeping/forcebalance/issues/307
   - setuptools<82

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -23,7 +23,8 @@ dependencies:
   - click-option-group
   - rdkit =2024.03.5
   - openff-utilities
-  - openff-toolkit >=0.15
+  - openff-toolkit >=0.16.5
+  - openff-interchange =0.3.29
   - openff-forcefields >=2024.04.0
   - openff-units
   - openff-qcsubmit >=0.55

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -38,8 +38,8 @@ dependencies:
     ### Bespoke dependencies
 
   - qcportal >=0.53
-  - qcelemental
-  - qcengine
+  - qcelemental <0.50
+  - qcengine <0.50
   - chemper
   - geometric =1
   - torsiondrive

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -22,8 +22,7 @@ dependencies:
   - click-option-group
   - rdkit =2024.03.5
   - openff-utilities
-  - openff-toolkit ==0.16.5
-  - openff-interchange ==0.3.29
+  - openff-toolkit >=0.15
   - openff-forcefields >=2024.04.0
   - openff-units
   - openff-qcsubmit >=0.55

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -1,6 +1,7 @@
 name: bespokefit-test
 
 channels:
+  - openeye
   - conda-forge
 
 dependencies:
@@ -32,7 +33,7 @@ dependencies:
   - forcebalance >=1.9.6
   - openff-fragmenter-base
   - xtb-python
-  - openeye::openeye-toolkits
+  - openeye-toolkits
 
     ### Bespoke dependencies
 

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -29,7 +29,7 @@ dependencies:
   - openmm >=7.6.0
 
     # Optional
-  - forcebalance ==1.9.6
+  - forcebalance >=1.9.6
   - openff-fragmenter-base
   - xtb-python
   - openeye::openeye-toolkits


### PR DESCRIPTION
## Description
New versions of these package use a new QCSchema which we do not currently support

## Todos
  - [x] Downpin `qcelemental <0.50`
  - [x] Downpin `qcengine <0.50`

## Status
- [x] Ready to go