### PR TITLE
Vendor AmberTools provenance

### DIFF
--- a/openff/bespokefit/optimizers/forcebalance/forcebalance.py
+++ b/openff/bespokefit/optimizers/forcebalance/forcebalance.py
@@ -5,7 +5,6 @@ import subprocess
 from typing import Any, Dict
 
 from openff.toolkit.typing.engines.smirnoff import ForceField
-from openff.utilities.provenance import get_ambertools_version
 
 from openff.bespokefit.optimizers.forcebalance import ForceBalanceInputFactory
 from openff.bespokefit.optimizers.model import BaseOptimizer
@@ -19,6 +18,7 @@ from openff.bespokefit.schema.targets import (
     TorsionProfileTargetSchema,
     VibrationTargetSchema,
 )
+from openff.bespokefit.utilities.provenance import get_ambertools_version
 from openff.bespokefit.utilities.smirnoff import ForceFieldEditor
 
 _logger = logging.getLogger(__name__)
@@ -60,7 +60,10 @@ class ForceBalanceOptimizer(BaseOptimizer):
         except ImportError:
             pass
 
-        ambertools_version = get_ambertools_version()
+        try:
+            ambertools_version = get_ambertools_version()
+        except Exception:
+            ambertools_version = None
 
         if ambertools_version is not None:
             versions["ambertools"] = ambertools_version

--- a/openff/bespokefit/utilities/provenance.py
+++ b/openff/bespokefit/utilities/provenance.py
@@ -1,0 +1,76 @@
+"""Provenance functions, vendored from `openff-utilities` v0.1.17"""
+
+import functools
+import json
+import os
+import subprocess
+import warnings
+
+
+class CondaExecutableNotFoundWarning(UserWarning):
+    """
+    A conda (or mamba/micromamba) executable is not found.
+    """
+
+
+@functools.lru_cache
+def _get_conda_list_package_versions() -> dict[str, str]:
+    """
+    Returns the versions of any packages found while executing `conda list`.
+    If no conda executable is found, emits CondaExecutableNotFoundWarning
+    """
+
+    if os.environ.get("PIXI_IN_SHELL") == "1" and os.environ.get("PIXI_EXE"):
+        conda_command = "{} list --json --manifest-path {}".format(
+            os.environ["PIXI_EXE"], os.environ["PIXI_PROJECT_MANIFEST"]
+        )
+    elif os.environ.get("CONDA_SHLVL", "0") != "0" and os.environ.get("CONDA_EXE"):
+        conda_command = "{} list --json".format(os.environ["CONDA_EXE"])
+    elif os.environ.get("CONDA_SHLVL", "0") != "0" and os.environ.get("MAMBA_EXE"):
+        conda_command = "{} list --json".format(os.environ["MAMBA_EXE"])
+    else:
+        warnings.warn(
+            "No conda/mamba/micromamba executable found. Unable to determine package versions.",
+            CondaExecutableNotFoundWarning,
+        )
+        return dict()
+
+    output = json.loads(subprocess.check_output(conda_command.split()).decode())
+
+    # micromamba >= 2.9.0 nests the package list under a "packages" key instead
+    # of returning it as the top-level array (mamba-org/mamba#4202, issue #156).
+    # conda, mamba, pixi, and micromamba < 2.9.0 all return the bare array.
+    if isinstance(output, dict):
+        output = output.get("packages", [])
+
+    package_versions = {}
+    for _package in output:
+        package_versions[_package["name"]] = _package["version"]
+
+    return package_versions
+
+
+def get_ambertools_version() -> str | None:
+    """
+    Attempts to retrieve the version of the currently installed AmberTools.
+
+    There are two soft failure modes, each of which cause this function to return `None`:
+        1. If there is a failure calling `{conda|mamba|etc.} list`, the user is
+            warned by `_get_conda_list_package_versions` and this function returns `None`.
+        2. If there is a failure calling `{conda|mamba|etc.} list`, this function
+            still returns `None`, but without a warning associated with the above failure.
+    """
+
+    try:
+        return _get_conda_list_package_versions().get("ambertools", None)
+    except (
+        ValueError,  # Issue 98
+        subprocess.CalledProcessError,  # Issue 101
+    ):
+        warnings.warn(
+            "Something went wrong parsing the output of `conda list` or similar. Unable to "
+            "determine AmberTools version, returning None.",
+            CondaExecutableNotFoundWarning,
+        )
+
+        return None


### PR DESCRIPTION
Unfortunately this won't work because the toolkit [also depends on this](https://github.com/openforcefield/openff-toolkit/blob/0.19.0/openff/toolkit/utils/ambertools_wrapper.py#L75-L80) unsupported code path - it probably should just live in the toolkit period

## Description
- [x] Port fix to `get_ambertools_version`
- [x] Squash any errors around above function

## Status
- [ ] Ready to go